### PR TITLE
fix: align with frappe develop and correct app metadata email

### DIFF
--- a/flow/hooks.py
+++ b/flow/hooks.py
@@ -2,7 +2,7 @@ app_name = "flow"
 app_title = "Flow"
 app_publisher = "Shrihari Mahabal"
 app_description = "Frappe Flow — native AI agents, tools, and triggers for Frappe"
-app_email = "shriharimahabal2@gmail.com"
+app_email = "shriharimahabal08@gmail.com"
 app_license = "mit"
 
 export_python_type_annotations = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "flow"
 authors = [
-    { name = "Shrihari Mahabal", email = "shriharimahabal2@gmail.com"}
+    { name = "Shrihari Mahabal", email = "shriharimahabal08@gmail.com"}
 ]
 description = "Frappe Flow — native AI agents, tools, and triggers for Frappe"
 requires-python = ">=3.14,<3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,6 @@ requires-python = ">=3.14,<3.15"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    # frappe (and litellm) are installed and managed by bench; keep litellm in
-    # frappe develop's supported range so the shared env resolves cleanly.
     "litellm<2,>=1.83.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,13 @@ authors = [
     { name = "Shrihari Mahabal", email = "shriharimahabal2@gmail.com"}
 ]
 description = "Frappe Flow — native AI agents, tools, and triggers for Frappe"
-requires-python = ">=3.14"
+requires-python = ">=3.14,<3.15"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    # "frappe~=16.0.0" # Installed and managed by bench.
-    "litellm==1.75.6",
+    # frappe (and litellm) are installed and managed by bench; keep litellm in
+    # frappe develop's supported range so the shared env resolves cleanly.
+    "litellm<2,>=1.83.0",
 ]
 
 [build-system]


### PR DESCRIPTION
Two pre-merge app-metadata corrections:

**Frappe develop compatibility**
- Frappe develop now bundles litellm (`<2,>=1.83.0`); the old `litellm==1.75.6` pin sat below frappe's floor (a hard `pip check` conflict) and dragged in `click 8.4.1` against frappe's `Click~=8.3.1`. Bumped to `<2,>=1.83.0` (click then resolves to 8.3.x automatically).
- Tightened `requires-python` to `>=3.14,<3.15` to match frappe develop.

**Author email**
- Set `pyproject.toml` author and `hooks.py` app_email to the GitHub-linked address `shriharimahabal08@gmail.com`.