### PR TITLE
fix: harden system-generated agent and tool sync

### DIFF
--- a/flow/ai/doctype/ai_agent/ai_agent.py
+++ b/flow/ai/doctype/ai_agent/ai_agent.py
@@ -89,7 +89,11 @@ class AIAgent(Document):
 	def _resolve_tools(self) -> list[Tool]:
 		resolved: list[Tool] = []
 		for row in self.tools:
-			tool_doc = frappe.get_doc("AI Tool", row.tool)
+			try:
+				tool_doc = frappe.get_doc("AI Tool", row.tool)
+			except frappe.DoesNotExistError:
+				frappe.log_error(title=f"AI Agent {self.name!r}: tool {row.tool!r} not found, skipping")
+				continue
 			if not tool_doc.enabled:
 				continue
 			resolved.append(tool_doc.to_tool())

--- a/flow/assistant.py
+++ b/flow/assistant.py
@@ -6,16 +6,6 @@ from __future__ import annotations
 import frappe
 
 ASSISTANT_AGENT_TITLE = "Assistant"
-ASSISTANT_TOOL_SLUGS = (
-	"find_doctypes",
-	"describe",
-	"read",
-	"create",
-	"update",
-	"delete",
-	"run_action",
-	"execute",
-)
 
 ASSISTANT_INSTRUCTIONS = (
 	"You are a Frappe assistant working inside a Frappe site.\n\n"
@@ -63,25 +53,38 @@ ASSISTANT_INSTRUCTIONS = (
 
 
 def sync_builtin_assistant(model: str | None = None) -> None:
-	"""Create the system Assistant agent if missing. `model` defaults to the first enabled AI Model."""
-	from flow.tools.builtins import sync_builtin_tools
+	"""Ensure the system Assistant agent exists and is up-to-date. Called from after_migrate and AIModel.after_insert."""
+	from flow.tools.builtins import BUILTIN_TOOLS, sync_builtin_tools
 
-	if frappe.db.exists("AI Agent", ASSISTANT_AGENT_TITLE):
-		return
+	sync_builtin_tools()
 
 	model_name = model or frappe.db.get_value("AI Model", {"enabled": 1}, "name")
 	if not model_name:
 		return
 
-	sync_builtin_tools()
-	frappe.get_doc(
-		{
-			"doctype": "AI Agent",
-			"title": ASSISTANT_AGENT_TITLE,
-			"model": model_name,
-			"instructions": ASSISTANT_INSTRUCTIONS,
-			"tools": [{"tool": slug} for slug in ASSISTANT_TOOL_SLUGS],
-			"enabled": 1,
-			"is_system_generated": 1,
-		}
-	).insert(ignore_permissions=True)
+	tool_slugs = [t.name for t in BUILTIN_TOOLS]
+
+	if not frappe.db.exists("AI Agent", ASSISTANT_AGENT_TITLE):
+		frappe.get_doc(
+			{
+				"doctype": "AI Agent",
+				"title": ASSISTANT_AGENT_TITLE,
+				"model": model_name,
+				"instructions": ASSISTANT_INSTRUCTIONS,
+				"tools": [{"tool": slug} for slug in tool_slugs],
+				"enabled": 1,
+				"is_system_generated": 1,
+			}
+		).insert(ignore_permissions=True)
+		return
+
+	doc = frappe.get_doc("AI Agent", ASSISTANT_AGENT_TITLE)
+	if not doc.is_system_generated:
+		return
+
+	doc.instructions = ASSISTANT_INSTRUCTIONS
+	existing = {row.tool for row in doc.tools}
+	for slug in tool_slugs:
+		if slug not in existing:
+			doc.append("tools", {"tool": slug})
+	doc.save(ignore_permissions=True)

--- a/flow/hooks.py
+++ b/flow/hooks.py
@@ -27,4 +27,4 @@ scheduler_events = {
 	},
 }
 
-after_migrate = ["flow.tools.builtins.sync_builtin_tools"]
+after_migrate = ["flow.assistant.sync_builtin_assistant"]

--- a/flow/tests/test_ai_assistant.py
+++ b/flow/tests/test_ai_assistant.py
@@ -7,9 +7,9 @@ from frappe.tests import IntegrationTestCase
 from flow.assistant import (
 	ASSISTANT_AGENT_TITLE,
 	ASSISTANT_INSTRUCTIONS,
-	ASSISTANT_TOOL_SLUGS,
 	sync_builtin_assistant,
 )
+from flow.tools.builtins import BUILTIN_TOOLS
 
 
 class TestSyncBuiltinAssistant(IntegrationTestCase):
@@ -38,17 +38,29 @@ class TestSyncBuiltinAssistant(IntegrationTestCase):
 		self.assertEqual(doc.instructions, ASSISTANT_INSTRUCTIONS)
 		self.assertTrue(doc.is_system_generated)
 		self.assertTrue(doc.enabled)
-		self.assertEqual(sorted(row.tool for row in doc.tools), sorted(ASSISTANT_TOOL_SLUGS))
+		expected_slugs = sorted(t.name for t in BUILTIN_TOOLS)
+		self.assertEqual(sorted(row.tool for row in doc.tools), expected_slugs)
 
-	def test_sync_is_noop_when_assistant_exists(self):
+	def test_sync_updates_instructions_on_existing_system_agent(self):
+		# sync_builtin_assistant should overwrite instructions on a system-generated agent.
 		original = frappe.get_doc("AI Agent", ASSISTANT_AGENT_TITLE)
-		original.instructions = "custom tweak"
+		original.instructions = "stale instructions"
 		original.save(ignore_permissions=True)
 
 		sync_builtin_assistant(model=self.model.name)
 
 		doc = frappe.get_doc("AI Agent", ASSISTANT_AGENT_TITLE)
-		self.assertEqual(doc.instructions, "custom tweak")
+		self.assertEqual(doc.instructions, ASSISTANT_INSTRUCTIONS)
+
+	def test_sync_is_noop_for_user_owned_agent(self):
+		# If is_system_generated was cleared (user took ownership), sync must not touch it.
+		frappe.db.set_value("AI Agent", ASSISTANT_AGENT_TITLE, "is_system_generated", 0)
+		frappe.db.set_value("AI Agent", ASSISTANT_AGENT_TITLE, "instructions", "user customised")
+
+		sync_builtin_assistant(model=self.model.name)
+
+		doc = frappe.get_doc("AI Agent", ASSISTANT_AGENT_TITLE)
+		self.assertEqual(doc.instructions, "user customised")
 
 	def test_assistant_cannot_be_deleted(self):
 		with self.assertRaisesRegex(frappe.ValidationError, "system-generated"):

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -345,33 +345,31 @@ BUILTIN_TOOLS: list[Tool] = [find_doctypes, describe, read, create, update, dele
 
 
 def sync_builtin_tools() -> None:
-	"""Register the builtin tools as AI Tool rows so agents can reference them."""
+	"""Upsert builtin tools as AI Tool rows. Uses db.set_value to bypass the immutability
+	guard in AITool.validate (which protects user edits, not system migration)."""
 	for builtin in BUILTIN_TOOLS:
+		import_path = f"flow.tools.builtins.{builtin.name}"
 		if frappe.db.exists("AI Tool", builtin.name):
-			current = frappe.db.get_value(
+			frappe.db.set_value(
 				"AI Tool",
 				builtin.name,
-				["is_system_generated", "requires_confirmation", "description"],
-				as_dict=True,
+				{
+					"import_path": import_path,
+					"description": builtin.description,
+					"requires_confirmation": int(builtin.requires_confirmation),
+					"is_system_generated": 1,
+				},
 			)
-			if not current.is_system_generated:
-				frappe.db.set_value("AI Tool", builtin.name, "is_system_generated", 1)
-			if bool(current.requires_confirmation) != builtin.requires_confirmation:
-				frappe.db.set_value(
-					"AI Tool", builtin.name, "requires_confirmation", int(builtin.requires_confirmation)
-				)
-			if current.description != builtin.description:
-				frappe.db.set_value("AI Tool", builtin.name, "description", builtin.description)
-			continue
-		frappe.get_doc(
-			{
-				"doctype": "AI Tool",
-				"slug": builtin.name,
-				"title": builtin.name.replace("_", " ").title(),
-				"kind": "Module",
-				"import_path": f"flow.tools.builtins.{builtin.name}",
-				"description": builtin.description,
-				"is_system_generated": 1,
-				"requires_confirmation": int(builtin.requires_confirmation),
-			}
-		).insert()
+		else:
+			frappe.get_doc(
+				{
+					"doctype": "AI Tool",
+					"slug": builtin.name,
+					"title": builtin.name.replace("_", " ").title(),
+					"kind": "Module",
+					"import_path": import_path,
+					"description": builtin.description,
+					"is_system_generated": 1,
+					"requires_confirmation": int(builtin.requires_confirmation),
+				}
+			).insert(ignore_permissions=True)


### PR DESCRIPTION
## Summary

- **`sync_builtin_tools`**: previously only updated 3 fields on existing rows; now upserts all mutable fields including `import_path` via `frappe.db.set_value` (intentionally bypasses the controller's immutability guard, which exists only to block user edits, not system migration)
- **`sync_builtin_assistant`**: was a no-op if the Assistant agent already existed — updated instructions and newly added builtins never propagated after an upgrade; now updates instructions and appends missing tool slugs on every call; also derives tool slugs from `BUILTIN_TOOLS` directly, removing the separately maintained `ASSISTANT_TOOL_SLUGS` tuple that could drift out of sync
- **`after_migrate`**: previously only wired to `sync_builtin_tools`; `sync_builtin_assistant` was never called on migrate (only on `AIModel.after_insert`), so existing sites with models in the DB never got a created/updated Assistant after a `bench migrate`; now `after_migrate` points to `sync_builtin_assistant`, which calls `sync_builtin_tools` internally
- **`AIAgent._resolve_tools`**: a deleted tool doc caused `DoesNotExistError` and the entire agent failed to assemble; now logs the missing tool and skips it
