### PR TITLE
fix(doctypes): add missing form script files for AI module doctypes

### DIFF
--- a/flow/ai/doctype/ai_agent/ai_agent.js
+++ b/flow/ai/doctype/ai_agent/ai_agent.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// License: MIT. See LICENSE
+
+frappe.ui.form.on("AI Agent", {
+	// refresh(frm) {
+	// },
+});

--- a/flow/ai/doctype/ai_agent_tool/ai_agent_tool.js
+++ b/flow/ai/doctype/ai_agent_tool/ai_agent_tool.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// License: MIT. See LICENSE
+
+frappe.ui.form.on("AI Agent Tool", {
+	// refresh(frm) {
+	// },
+});

--- a/flow/ai/doctype/ai_provider/ai_provider.js
+++ b/flow/ai/doctype/ai_provider/ai_provider.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// License: MIT. See LICENSE
+
+frappe.ui.form.on("AI Provider", {
+	// refresh(frm) {
+	// },
+});

--- a/flow/ai/doctype/ai_run/ai_run.js
+++ b/flow/ai/doctype/ai_run/ai_run.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// License: MIT. See LICENSE
+
+frappe.ui.form.on("AI Run", {
+	// refresh(frm) {
+	// },
+});

--- a/flow/ai/doctype/ai_session/ai_session.js
+++ b/flow/ai/doctype/ai_session/ai_session.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// License: MIT. See LICENSE
+
+frappe.ui.form.on("AI Session", {
+	// refresh(frm) {
+	// },
+});

--- a/flow/ai/doctype/ai_session_message/ai_session_message.js
+++ b/flow/ai/doctype/ai_session_message/ai_session_message.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// License: MIT. See LICENSE
+
+frappe.ui.form.on("AI Session Message", {
+	// refresh(frm) {
+	// },
+});

--- a/flow/ai/doctype/ai_tool/ai_tool.js
+++ b/flow/ai/doctype/ai_tool/ai_tool.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// License: MIT. See LICENSE
+
+frappe.ui.form.on("AI Tool", {
+	// refresh(frm) {
+	// },
+});

--- a/flow/ai/doctype/ai_trigger/ai_trigger.js
+++ b/flow/ai/doctype/ai_trigger/ai_trigger.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2026, Frappe Technologies and contributors
+// License: MIT. See LICENSE
+
+frappe.ui.form.on("AI Trigger", {
+	// refresh(frm) {
+	// },
+});


### PR DESCRIPTION
Each Frappe doctype should ship with a .js form script. The AI Agent, AI Agent Tool, AI Provider, AI Run, AI Session, AI Session Message, AI Tool and AI Trigger doctypes were missing these files.