### PR TITLE
refactor: session doc as the runtime handle

### DIFF
--- a/flow/ai/doctype/ai_agent/ai_agent.py
+++ b/flow/ai/doctype/ai_agent/ai_agent.py
@@ -100,7 +100,7 @@ class AIAgent(Document):
 		return resolved
 
 	def new_session(self, *, model: str | None = None, title: str | None = None):
-		"""Start a conversation driven by this agent. Returns a `flow.session.Session`."""
+		"""Start a conversation driven by this agent. Returns an AISession doc with runtime attached."""
 		from flow.lib.session import new_session
 
 		return new_session(self, model=model, title=title)

--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -4,13 +4,21 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import frappe
 from frappe import _
 from frappe.model.document import Document
 
+if TYPE_CHECKING:
+	from collections.abc import Generator
+
+	from flow.ai.doctype.ai_run.ai_run import AIRun
+	from flow.lib.agent import Event
+
 TITLE_MAX_LENGTH = 80
+# A "Running" run older than this is treated as abandoned and no longer blocks the session.
+RUNNING_STALE_SECONDS = 300
 
 
 class AISession(Document):
@@ -89,6 +97,107 @@ class AISession(Document):
 				},
 			)
 		self.save(ignore_permissions=True)
+
+	def chat(
+		self,
+		input: str,
+		*,
+		source: str = "Manual",
+		trigger: str | None = None,
+		stream: bool = False,
+	) -> AIRun | Generator[Event]:
+		"""Run one turn and persist it as an AI Run. With `stream=True`, returns an event generator."""
+		from flow.ai.doctype.ai_run.ai_run import create_run, stream_with_persistence
+
+		self.reload()
+		self._assert_not_blocked()
+		if not self.title:
+			self.db_set("title", derive_title(input))
+
+		run_input = self._build_input(input)
+		run = create_run(
+			source=source,
+			input=input,
+			session=self.name,
+			trigger=trigger,
+			config_snapshot=self._snapshot,
+		)
+
+		if stream:
+			return stream_with_persistence(lambda: self._runtime.run(run_input, stream=True), run)
+
+		try:
+			result = self._runtime.run(run_input)
+		except Exception as e:
+			run.mark_failed(str(e))
+			raise
+		run.apply_result(result)
+		return run
+
+	def resume(self, answers: dict[str, Any], *, stream: bool = False) -> AIRun | Generator[Event]:
+		"""Resume this session's paused run with the user's answers."""
+		from flow.ai.doctype.ai_run.ai_run import stream_with_persistence
+
+		run_name = frappe.db.get_value(
+			"AI Run",
+			{"session": self.name, "status": "Paused"},
+			"name",
+			order_by="creation desc",
+		)
+		if not run_name:
+			frappe.throw(_("This session has no paused run to resume."), title=_("Nothing to Resume"))
+		run = frappe.get_doc("AI Run", run_name)
+
+		self.reload()
+		messages = self.transcript()
+		if not messages:
+			frappe.throw(_("This session has no transcript to resume from."))
+
+		if stream:
+			return stream_with_persistence(lambda: self._runtime.resume(messages, answers, stream=True), run)
+
+		try:
+			result = self._runtime.resume(messages, answers)
+		except Exception as e:
+			run.mark_failed(str(e))
+			raise
+		run.apply_result(result)
+		return run
+
+	def _build_input(self, new_input: str) -> str | list[dict[str, Any]]:
+		transcript = self.transcript()
+		if not transcript:
+			return new_input
+		transcript.append({"role": "user", "content": new_input})
+		return transcript
+
+	def _assert_not_blocked(self) -> None:
+		blocking = frappe.db.get_value(
+			"AI Run",
+			{"session": self.name, "status": ("in", ["Paused", "Running"])},
+			["name", "status", "creation"],
+			order_by="creation desc",
+			as_dict=True,
+		)
+		if not blocking:
+			return
+		if blocking.status == "Paused":
+			frappe.throw(
+				_("This session has a paused run. Resume it before starting a new turn."),
+				title=_("Run Paused"),
+			)
+		age = frappe.utils.time_diff_in_seconds(frappe.utils.now_datetime(), blocking.creation)
+		if age > RUNNING_STALE_SECONDS:
+			frappe.db.set_value(
+				"AI Run",
+				blocking.name,
+				{"status": "Failed", "error": "Run abandoned: stream ended without completing."},
+			)
+			return
+		frappe.throw(
+			_("This session already has a run in progress."),
+			title=_("Run In Progress"),
+		)
 
 
 def derive_title(text: str) -> str:

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -125,10 +125,18 @@ class Agent:
 		the tool, "Deny" blocks it, and any other free text is returned to the LLM as
 		redirect feedback so it can adjust and retry.
 		"""
-		messages = self._prepare_resume(messages, answers)
 		if stream:
-			return self._loop_stream(messages)
+			return self._resume_stream(messages, answers)
+		messages, _ = self._prepare_resume(messages, answers)
 		return self._loop(messages)
+
+	def _resume_stream(self, messages: list[dict[str, Any]], answers: dict[str, Any]) -> Generator[Event]:
+		"""Stream a resume: first replay the just-resolved tool results so the UI can fill in
+		the tool cards that were awaiting an answer, then continue the agent loop."""
+		messages, resolved = self._prepare_resume(messages, answers)
+		for call, content in resolved:
+			yield ToolEnded(id=call.id, name=call.name, result=content)
+		yield from self._loop_stream(messages)
 
 	def new_session(self, *, title: str | None = None) -> Any:
 		"""Start a persisted conversation driven by this code agent (session's agent link is left empty)."""
@@ -148,13 +156,16 @@ class Agent:
 
 	def _prepare_resume(
 		self, messages: list[dict[str, Any]], answers: dict[str, Any]
-	) -> list[dict[str, Any]]:
+	) -> tuple[list[dict[str, Any]], list[tuple[ToolCall, str]]]:
+		"""Append a tool result for each pending call. Returns the new messages plus the
+		(call, content) pairs resolved, so a streaming resume can replay them as events."""
 		_validate_messages(messages)
 		messages = list(messages)
 		pending = self._pending_calls(messages)
 		if not pending:
 			raise ValueError("No questions awaiting an answer in the provided messages")
 
+		resolved: list[tuple[ToolCall, str]] = []
 		for call in pending:
 			answer = answers.get(call.id)
 			tool = self._tools_by_name.get(call.name)
@@ -163,7 +174,8 @@ class Agent:
 			else:
 				content = _serialize_tool_result(answer)
 			messages.append({"role": "tool", "tool_call_id": call.id, "content": content})
-		return messages
+			resolved.append((call, content))
+		return messages, resolved
 
 	def _resolve_confirmation(self, call: ToolCall, answer: Any) -> str:
 		"""Run the tool if approved; deny if rejected; redirect with user feedback otherwise."""

--- a/flow/lib/resolver.py
+++ b/flow/lib/resolver.py
@@ -53,7 +53,7 @@ def _resolve_module(doc: AITool) -> Tool:
 		)
 
 	if isinstance(obj, Tool):
-		return _build_tool(doc, obj.parameters, obj.func)
+		return _build_tool(doc, obj.parameters, obj.func, confirm_prompt=obj.confirm_prompt)
 	if callable(obj):
 		return _build_tool(doc, build_schema(obj), obj)
 	frappe.throw(
@@ -67,13 +67,14 @@ def _resolve_script(doc: AITool, *, restrict_commit_rollback: bool = False) -> T
 	return _build_tool(doc, schema_from_code(doc.code), runner)
 
 
-def _build_tool(doc: AITool, parameters: dict[str, Any], func: Any) -> Tool:
+def _build_tool(doc: AITool, parameters: dict[str, Any], func: Any, *, confirm_prompt: Any = None) -> Tool:
 	return Tool(
 		name=doc.slug,
 		description=doc.description,
 		parameters=parameters,
 		func=func,
 		requires_confirmation=bool(doc.requires_confirmation),
+		confirm_prompt=confirm_prompt,
 	)
 
 

--- a/flow/lib/session.py
+++ b/flow/lib/session.py
@@ -9,143 +9,12 @@ import frappe
 from frappe import _
 
 if TYPE_CHECKING:
-	from collections.abc import Generator
-
 	from flow.ai.doctype.ai_run.ai_run import AIRun
 	from flow.ai.doctype.ai_session.ai_session import AISession
-	from flow.lib.agent import Agent, Event
-
-# A "Running" run older than this is treated as abandoned (its stream died without
-# persisting a terminal state), so it no longer blocks new turns in the session.
-RUNNING_STALE_SECONDS = 300
+	from flow.lib.agent import Agent
 
 
-class Session:
-	"""Runtime handle over an AI Session: the persisted conversation plus the runtime that
-	drives it. Create one with `new_session()` / `agent.new_session()`, resume with
-	`load_session()`, and run turns with `chat()` / `resume()`."""
-
-	def __init__(self, doc: AISession, runtime: Agent, snapshot: dict[str, Any]):
-		self._doc = doc
-		self._runtime = runtime
-		self._snapshot = snapshot
-
-	@property
-	def id(self) -> str:
-		return self._doc.name
-
-	@property
-	def doc(self) -> AISession:
-		return self._doc
-
-	def chat(
-		self,
-		input: str,
-		*,
-		source: str = "Manual",
-		trigger: str | None = None,
-		stream: bool = False,
-	) -> AIRun | Generator[Event]:
-		"""Run one turn and persist it as an AI Run. With `stream=True`, returns an event generator."""
-		from flow.ai.doctype.ai_run.ai_run import create_run, stream_with_persistence
-
-		self._doc.reload()
-		self._assert_not_blocked()
-		if not self._doc.title:
-			self._doc.db_set("title", _derive_title(input))
-
-		run_input = self._build_input(input)
-		run = create_run(
-			source=source,
-			input=input,
-			session=self._doc.name,
-			trigger=trigger,
-			config_snapshot=self._snapshot,
-		)
-
-		if stream:
-			return stream_with_persistence(lambda: self._runtime.run(run_input, stream=True), run)
-
-		try:
-			result = self._runtime.run(run_input)
-		except Exception as e:
-			run.mark_failed(str(e))
-			raise
-		run.apply_result(result)
-		return run
-
-	def resume(self, answers: dict[str, Any], *, stream: bool = False) -> AIRun | Generator[Event]:
-		"""Resume this session's paused run with the user's answers."""
-		from flow.ai.doctype.ai_run.ai_run import stream_with_persistence
-
-		run_name = frappe.db.get_value(
-			"AI Run",
-			{"session": self._doc.name, "status": "Paused"},
-			"name",
-			order_by="creation desc",
-		)
-		if not run_name:
-			frappe.throw(_("This session has no paused run to resume."), title=_("Nothing to Resume"))
-		run = frappe.get_doc("AI Run", run_name)
-
-		self._doc.reload()
-		messages = self._doc.transcript()
-		if not messages:
-			frappe.throw(_("This session has no transcript to resume from."))
-
-		if stream:
-			return stream_with_persistence(lambda: self._runtime.resume(messages, answers, stream=True), run)
-
-		try:
-			result = self._runtime.resume(messages, answers)
-		except Exception as e:
-			run.mark_failed(str(e))
-			raise
-		run.apply_result(result)
-		return run
-
-	def _build_input(self, new_input: str) -> str | list[dict[str, Any]]:
-		"""First turn → the raw string (the agent prepends its system prompt). Later turns →
-		the transcript so far with the new user message appended."""
-		transcript = self._doc.transcript()
-		if not transcript:
-			return new_input
-		transcript.append({"role": "user", "content": new_input})
-		return transcript
-
-	def _assert_not_blocked(self) -> None:
-		blocking = frappe.db.get_value(
-			"AI Run",
-			{"session": self._doc.name, "status": ("in", ["Paused", "Running"])},
-			["name", "status", "creation"],
-			order_by="creation desc",
-			as_dict=True,
-		)
-		if not blocking:
-			return
-		if blocking.status == "Paused":
-			frappe.throw(
-				_("This session has a paused run. Resume it before starting a new turn."),
-				title=_("Run Paused"),
-			)
-		# A "Running" run whose stream died without persisting (client disconnect, restart)
-		# would block the session forever. Recover it once it's clearly stale; otherwise a
-		# genuinely in-progress turn still blocks concurrent sends.
-		age = frappe.utils.time_diff_in_seconds(frappe.utils.now_datetime(), blocking.creation)
-		if age > RUNNING_STALE_SECONDS:
-			frappe.db.set_value(
-				"AI Run",
-				blocking.name,
-				{"status": "Failed", "error": "Run abandoned: stream ended without completing."},
-			)
-			return
-		frappe.throw(
-			_("This session already has a run in progress."),
-			title=_("Run In Progress"),
-		)
-
-
-def new_session(agent: Any = None, *, model: str | None = None, title: str | None = None) -> Session:
+def new_session(agent: Any = None, *, model: str | None = None, title: str | None = None) -> AISession:
 	"""Start a conversation. `agent` may be a code `Agent`, an AI Agent doc, an agent name,
 	or None for the default Assistant. Code agents leave the session's agent link empty."""
 	runtime, agent_name, session_model, snapshot = _resolve_new_agent(agent, model)
@@ -157,10 +26,12 @@ def new_session(agent: Any = None, *, model: str | None = None, title: str | Non
 			"title": title,
 		}
 	).insert(ignore_permissions=True)
-	return Session(doc, runtime, snapshot)
+	doc._runtime = runtime
+	doc._snapshot = snapshot
+	return doc
 
 
-def load_session(name: str, *, agent: Any = None, model: str | None = None) -> Session:
+def load_session(name: str, *, agent: Any = None, model: str | None = None) -> AISession:
 	"""Resume an existing conversation by id. Doctype-backed sessions rebuild their runtime
 	automatically; code-agent sessions require the same `Agent` to be passed again."""
 	doc = frappe.get_doc("AI Session", name)
@@ -176,8 +47,8 @@ def load_session(name: str, *, agent: Any = None, model: str | None = None) -> S
 		doc.model = model
 		doc.save(ignore_permissions=True)
 
-	runtime, snapshot = _resolve_existing_agent(doc, agent)
-	return Session(doc, runtime, snapshot)
+	doc._runtime, doc._snapshot = _resolve_existing_agent(doc, agent)
+	return doc
 
 
 def _resolve_new_agent(agent: Any, model: str | None) -> tuple[Agent, str | None, str | None, dict[str, Any]]:
@@ -222,12 +93,6 @@ def _default_agent_name() -> str:
 			title=_("Missing Default Agent"),
 		)
 	return ASSISTANT_AGENT_TITLE
-
-
-def _derive_title(text: str) -> str:
-	from flow.ai.doctype.ai_session.ai_session import derive_title
-
-	return derive_title(text)
 
 
 def _assert_session_owner(doc: AISession) -> None:

--- a/flow/lib/session.py
+++ b/flow/lib/session.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
 	from flow.ai.doctype.ai_session.ai_session import AISession
 	from flow.lib.agent import Agent, Event
 
+# A "Running" run older than this is treated as abandoned (its stream died without
+# persisting a terminal state), so it no longer blocks new turns in the session.
+RUNNING_STALE_SECONDS = 300
+
 
 class Session:
 	"""Runtime handle over an AI Session: the persisted conversation plus the runtime that
@@ -113,19 +117,32 @@ class Session:
 		blocking = frappe.db.get_value(
 			"AI Run",
 			{"session": self._doc.name, "status": ("in", ["Paused", "Running"])},
-			"status",
+			["name", "status", "creation"],
 			order_by="creation desc",
+			as_dict=True,
 		)
-		if blocking == "Paused":
+		if not blocking:
+			return
+		if blocking.status == "Paused":
 			frappe.throw(
 				_("This session has a paused run. Resume it before starting a new turn."),
 				title=_("Run Paused"),
 			)
-		if blocking == "Running":
-			frappe.throw(
-				_("This session already has a run in progress."),
-				title=_("Run In Progress"),
+		# A "Running" run whose stream died without persisting (client disconnect, restart)
+		# would block the session forever. Recover it once it's clearly stale; otherwise a
+		# genuinely in-progress turn still blocks concurrent sends.
+		age = frappe.utils.time_diff_in_seconds(frappe.utils.now_datetime(), blocking.creation)
+		if age > RUNNING_STALE_SECONDS:
+			frappe.db.set_value(
+				"AI Run",
+				blocking.name,
+				{"status": "Failed", "error": "Run abandoned: stream ended without completing."},
 			)
+			return
+		frappe.throw(
+			_("This session already has a run in progress."),
+			title=_("Run In Progress"),
+		)
 
 
 def new_session(agent: Any = None, *, model: str | None = None, title: str | None = None) -> Session:

--- a/flow/tests/test_session.py
+++ b/flow/tests/test_session.py
@@ -116,7 +116,7 @@ class TestSessionModelOverride(IntegrationTestCase):
 
 	def test_new_session_applies_model_override(self):
 		convo = new_session(self.agent_doc, model=self.model_b.name)
-		self.assertEqual(convo.doc.model, self.model_b.name)
+		self.assertEqual(convo.model, self.model_b.name)
 
 		with patch.object(Model, "chat", return_value=_final()):
 			run = convo.chat("hi")
@@ -128,8 +128,8 @@ class TestSessionModelOverride(IntegrationTestCase):
 			first = convo.chat("hi")
 		self.assertEqual(json.loads(first.config_snapshot)["model"], self.model_a.name)
 
-		switched = load_session(convo.id, model=self.model_b.name)
-		self.assertEqual(switched.doc.model, self.model_b.name)
+		switched = load_session(convo.name, model=self.model_b.name)
+		self.assertEqual(switched.model, self.model_b.name)
 
 		with patch.object(Model, "chat", return_value=_final()):
 			second = switched.chat("again")


### PR DESCRIPTION
## Summary
- `chat()`, `resume()`, `_assert_not_blocked()`, `_build_input()` moved onto `AISession` — the doc is now the handle
- `Session` wrapper class removed; factories (`new_session`, `load_session`) attach `_runtime` and `_snapshot` as instance attributes and return the doc directly
- Includes backend fixes: streaming resume emits `ToolEnded` events, resolver passes `confirm_prompt`, stale `Running` runs auto-recover after 300s

## Test plan
- [ ] Existing session tests pass (`test_session.py`)
- [ ] `convo.name` replaces `convo.id`, `convo.model` replaces `convo.doc.model` in tests
- [ ] Code agent path: `agent.new_session().chat()` works unchanged
- [ ] Doctype agent path: `load_session(name).chat()` works unchanged