### PR TITLE
refactor(ai-tool): rename kind→type, Module→Imported

### DIFF
--- a/flow/ai/doctype/ai_tool/ai_tool.json
+++ b/flow/ai/doctype/ai_tool/ai_tool.json
@@ -9,7 +9,7 @@
   "title",
   "slug",
   "column_break_meta",
-  "kind",
+  "type",
   "enabled",
   "requires_confirmation",
   "is_system_generated",
@@ -43,14 +43,14 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "Module",
-   "description": "<code>Module</code> tools are imported from a Python module by path. <code>Script</code> tools store code in the database and run it in a <code>safe_exec</code> sandbox.",
-   "fieldname": "kind",
+   "default": "Imported",
+   "description": "<code>Imported</code> tools are loaded from a Python module by path. <code>Script</code> tools store code in the database and run it in a <code>safe_exec</code> sandbox.",
+   "fieldname": "type",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Kind",
-   "options": "Module\nScript",
+   "label": "Type",
+   "options": "Imported\nScript",
    "reqd": 1
   },
   {
@@ -85,7 +85,7 @@
    "reqd": 1
   },
   {
-   "depends_on": "eval:doc.kind === 'Script'",
+   "depends_on": "eval:doc.type === 'Script'",
    "description": "Optional plain-English summary for human reviewers.",
    "fieldname": "summary",
    "fieldtype": "Small Text",
@@ -97,20 +97,20 @@
    "label": "Definition"
   },
   {
-   "depends_on": "eval:doc.kind === 'Module'",
+   "depends_on": "eval:doc.type === 'Imported'",
    "description": "Dotted Python path to the <code>Tool</code> object, e.g. <code>flow.tools.builtins.search_doctypes</code>.",
    "fieldname": "import_path",
    "fieldtype": "Data",
    "label": "Import Path",
-   "mandatory_depends_on": "eval:doc.kind === 'Module'"
+   "mandatory_depends_on": "eval:doc.type === 'Imported'"
   },
   {
-   "depends_on": "eval:doc.kind === 'Script'",
+   "depends_on": "eval:doc.type === 'Script'",
    "description": "Python source. Must define a top-level <code>main</code> function. Executed in a server-script sandbox.",
    "fieldname": "code",
    "fieldtype": "Code",
    "label": "Code",
-   "mandatory_depends_on": "eval:doc.kind === 'Script'",
+   "mandatory_depends_on": "eval:doc.type === 'Script'",
    "options": "Python"
   }
  ],

--- a/flow/ai/doctype/ai_tool/ai_tool.py
+++ b/flow/ai/doctype/ai_tool/ai_tool.py
@@ -29,25 +29,25 @@ class AITool(Document):
 		enabled: DF.Check
 		import_path: DF.Data | None
 		is_system_generated: DF.Check
-		kind: DF.Literal["Module", "Script"]
 		requires_confirmation: DF.Check
 		slug: DF.Data
 		summary: DF.SmallText | None
 		title: DF.Data
+		type: DF.Literal["Imported", "Script"]
 	# end: auto-generated types
 
 	def validate(self):
 		self._normalize()
 		self._validate_slug()
-		self._validate_kind_fields()
-		if self.kind == "Script":
+		self._validate_type_fields()
+		if self.type == "Script":
 			self._validate_code()
 		self._validate_system_generated_immutable()
 
 	def _validate_system_generated_immutable(self):
 		if not self.is_system_generated or self.is_new():
 			return
-		before = frappe.db.get_value("AI Tool", self.name, ["import_path", "kind"], as_dict=True)
+		before = frappe.db.get_value("AI Tool", self.name, ["import_path", "type"], as_dict=True)
 		if before is None:
 			return
 		if before.import_path != self.import_path:
@@ -55,9 +55,9 @@ class AITool(Document):
 				_("Cannot change import path of system-generated tool {0}.").format(self.name),
 				title=_("Protected"),
 			)
-		if before.kind != self.kind:
+		if before.type != self.type:
 			frappe.throw(
-				_("Cannot change kind of system-generated tool {0}.").format(self.name),
+				_("Cannot change type of system-generated tool {0}.").format(self.name),
 				title=_("Protected"),
 			)
 
@@ -96,10 +96,10 @@ class AITool(Document):
 				title=_("Invalid Slug"),
 			)
 
-	def _validate_kind_fields(self):
-		if self.kind == "Module":
+	def _validate_type_fields(self):
+		if self.type == "Imported":
 			if not self.import_path:
-				frappe.throw(_("Import Path is required for Module tools."), title=_("Missing Import Path"))
+				frappe.throw(_("Import Path is required for Imported tools."), title=_("Missing Import Path"))
 			if not IMPORT_PATH_PATTERN.match(self.import_path):
 				frappe.throw(
 					_(
@@ -108,8 +108,8 @@ class AITool(Document):
 					title=_("Invalid Import Path"),
 				)
 			if self.code:
-				frappe.throw(_("Module tools must not define inline code."), title=_("Unexpected Code"))
-		elif self.kind == "Script":
+				frappe.throw(_("Imported tools must not define inline code."), title=_("Unexpected Code"))
+		elif self.type == "Script":
 			if not self.code:
 				frappe.throw(_("Code is required for Script tools."), title=_("Missing Code"))
 			if self.import_path:
@@ -118,7 +118,7 @@ class AITool(Document):
 					title=_("Unexpected Import Path"),
 				)
 		else:
-			frappe.throw(_("Kind must be Module or Script."), title=_("Invalid Kind"))
+			frappe.throw(_("Type must be Imported or Script."), title=_("Invalid Type"))
 
 	def _validate_code(self):
 		try:

--- a/flow/ai/doctype/ai_tool/test_ai_tool.py
+++ b/flow/ai/doctype/ai_tool/test_ai_tool.py
@@ -17,7 +17,7 @@ def _module(**overrides: Any) -> dict:
 		"doctype": "AI Tool",
 		"title": "Get Weather",
 		"slug": "get_weather",
-		"kind": "Module",
+		"type": "Imported",
 		"description": "Returns weather for a city.",
 		"import_path": "flow.tools.builtins.get_weather",
 	}
@@ -29,7 +29,7 @@ def _script(**overrides: Any) -> dict:
 	doc = _module(
 		slug="script_weather",
 		title="Script Weather",
-		kind="Script",
+		type="Script",
 		import_path=None,
 		code=VALID_SCRIPT_CODE,
 	)
@@ -44,12 +44,12 @@ class IntegrationTestAITool(IntegrationTestCase):
 	def test_module_tool_creates_successfully(self):
 		doc = frappe.get_doc(_module()).insert()
 		self.assertEqual(doc.name, "get_weather")
-		self.assertEqual(doc.kind, "Module")
+		self.assertEqual(doc.type, "Imported")
 
 	def test_script_tool_creates_successfully(self):
 		doc = frappe.get_doc(_script()).insert()
 		self.assertEqual(doc.name, "script_weather")
-		self.assertEqual(doc.kind, "Script")
+		self.assertEqual(doc.type, "Script")
 
 	def test_slug_must_be_snake_case(self):
 		for bad in ("bad-slug", "1starts_with_digit", "bad slug", "has.dot", "HasCaps"):

--- a/flow/lib/resolver.py
+++ b/flow/lib/resolver.py
@@ -38,7 +38,7 @@ def resolve_tool(doc: AITool, *, restrict_commit_rollback: bool = False) -> Tool
 	`restrict_commit_rollback` removes commit/rollback from a Script tool's sandbox,
 	so it cannot escape a surrounding test transaction.
 	"""
-	if doc.kind == "Module":
+	if doc.type == "Imported":
 		return _resolve_module(doc)
 	return _resolve_script(doc, restrict_commit_rollback=restrict_commit_rollback)
 

--- a/flow/tests/test_ai_resolver.py
+++ b/flow/tests/test_ai_resolver.py
@@ -110,7 +110,7 @@ def _module_doc(**overrides: Any) -> dict:
 		"doctype": "AI Tool",
 		"title": "Weather",
 		"slug": "weather",
-		"kind": "Module",
+		"type": "Imported",
 		"description": "Look up the weather.",
 		"import_path": "flow.tools.builtins.weather",
 	}
@@ -123,7 +123,7 @@ def _script_doc(**overrides: Any) -> dict:
 		"doctype": "AI Tool",
 		"title": "Script Weather",
 		"slug": "script_weather",
-		"kind": "Script",
+		"type": "Script",
 		"description": "Look up the weather.",
 		"code": SCRIPT_CODE,
 	}

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -366,7 +366,7 @@ def sync_builtin_tools() -> None:
 					"doctype": "AI Tool",
 					"slug": builtin.name,
 					"title": builtin.name.replace("_", " ").title(),
-					"kind": "Module",
+					"type": "Imported",
 					"import_path": import_path,
 					"description": builtin.description,
 					"is_system_generated": 1,


### PR DESCRIPTION
Renames the `kind` field to `type` (clearer label, consistent with Frappe conventions) and the `Module` option to `Imported` (avoids collision with Frappe's own Module concept). Updates controller, callsites, and tests.