### PR TITLE
fix(agent): preserve tool_calls, iterations, and usage across pause/resume

### DIFF
--- a/flow/ai/doctype/ai_run/ai_run.py
+++ b/flow/ai/doctype/ai_run/ai_run.py
@@ -83,13 +83,17 @@ class AIRun(Document):
 
 	def apply_result(self, result: RunResult) -> None:
 		"""Update this row to reflect a (re-)executed Agent run. The new messages produced
-		by this run are appended to the parent Session's transcript."""
+		by this run are appended to the parent Session's transcript.
+
+		Resume re-invokes this on the same run: tool_calls already carries the full set (the
+		agent seeds it from the transcript), while iterations and usage accumulate here.
+		"""
 		self.status = _status_from_result(result)
-		self.iterations = result.iterations
+		self.iterations = (self.iterations or 0) + result.iterations
 		self.output = result.output
 		self.tool_calls = _dump_json([asdict(call) for call in result.tool_calls])
 		self.questions = _dump_json([asdict(q) for q in result.questions]) if result.paused else None
-		self.usage = _dump_json(result.usage)
+		self.usage = _dump_json(_merge_usage(self.usage, result.usage))
 		if self.status != "Failed":
 			self.error = None
 		self.save(ignore_permissions=True)
@@ -213,6 +217,14 @@ def _dump_json(value: Any) -> str | None:
 	if value is None:
 		return None
 	return json.dumps(value, default=str)
+
+
+def _merge_usage(existing: str | None, new: dict[str, int]) -> dict[str, int]:
+	"""Add token counts from a (resumed) segment onto whatever the run already recorded."""
+	merged = json.loads(existing) if existing else {}
+	for key, value in new.items():
+		merged[key] = merged.get(key, 0) + value
+	return merged
 
 
 def _json_has_items(value: Any) -> bool:

--- a/flow/ai/doctype/ai_run/test_ai_run.py
+++ b/flow/ai/doctype/ai_run/test_ai_run.py
@@ -167,6 +167,20 @@ class TestAIRunPersistence(IntegrationTestCase):
 		self.assertIsNone(doc.questions)
 		self.assertEqual(doc.output, "emailed")
 
+	def test_resume_accumulates_iterations_and_usage(self):
+		session = _new_session(self.agent)
+		doc = persist_result(_paused_result(), source="Manual", input="delete the records", session=session)
+		self.assertEqual(doc.iterations, 1)
+		self.assertEqual(json.loads(doc.usage)["total_tokens"], 6)
+
+		doc.apply_result(_completed_result("emailed"))
+
+		# A resumed run continues the same row: counts span both segments.
+		self.assertEqual(doc.iterations, 2)
+		self.assertEqual(
+			json.loads(doc.usage), {"prompt_tokens": 7, "completion_tokens": 4, "total_tokens": 11}
+		)
+
 	def test_persist_records_usage(self):
 		session = _new_session(self.agent)
 		doc = persist_result(_tooled_result(), source="Manual", input="x", session=session)

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -128,7 +128,7 @@ class Agent:
 		if stream:
 			return self._resume_stream(messages, answers)
 		messages, _ = self._prepare_resume(messages, answers)
-		return self._loop(messages)
+		return self._loop(messages, self._answered_calls(messages))
 
 	def _resume_stream(self, messages: list[dict[str, Any]], answers: dict[str, Any]) -> Generator[Event]:
 		"""Stream a resume: first replay the just-resolved tool results so the UI can fill in
@@ -136,7 +136,7 @@ class Agent:
 		messages, resolved = self._prepare_resume(messages, answers)
 		for call, content in resolved:
 			yield ToolEnded(id=call.id, name=call.name, result=content)
-		yield from self._loop_stream(messages)
+		yield from self._loop_stream(messages, self._answered_calls(messages))
 
 	def new_session(self, *, title: str | None = None) -> Any:
 		"""Start a persisted conversation driven by this code agent (session's agent link is left empty)."""
@@ -245,9 +245,11 @@ class Agent:
 
 		raise RuntimeError(f"Agent {self.name!r} exceeded max_iterations ({self.max_iterations})")
 
-	def _loop_stream(self, messages: list[dict[str, Any]]) -> Generator[Event]:
+	def _loop_stream(
+		self, messages: list[dict[str, Any]], executed_calls: list[ToolCall] | None = None
+	) -> Generator[Event]:
 		tool_schemas = [t.to_dict() for t in self.tools] or None
-		executed_calls: list[ToolCall] = []
+		executed_calls = executed_calls if executed_calls is not None else []
 		usage_total = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
 		for iteration in range(1, self.max_iterations + 1):
@@ -305,18 +307,25 @@ class Agent:
 
 	def _pending_calls(self, messages: list[dict[str, Any]]) -> list[ToolCall]:
 		"""Tool calls in the transcript that have no tool result yet (awaiting an answer)."""
-		answered = {m.get("tool_call_id") for m in messages if m.get("role") == "tool"}
-		pending: list[ToolCall] = []
+		return self._transcript_calls(messages, answered=False)
+
+	def _answered_calls(self, messages: list[dict[str, Any]]) -> list[ToolCall]:
+		"""Tool calls in the transcript that already have a tool result (executed)."""
+		return self._transcript_calls(messages, answered=True)
+
+	def _transcript_calls(self, messages: list[dict[str, Any]], *, answered: bool) -> list[ToolCall]:
+		has_result = {m.get("tool_call_id") for m in messages if m.get("role") == "tool"}
+		calls: list[ToolCall] = []
 		for message in messages:
 			if message.get("role") != "assistant":
 				continue
 			for tc in message.get("tool_calls") or []:
-				if tc["id"] in answered:
+				if (tc["id"] in has_result) != answered:
 					continue
 				fn = tc["function"]
 				arguments = fn.get("arguments") or "{}"
-				pending.append(ToolCall(id=tc["id"], name=fn["name"], arguments=json.loads(arguments)))
-		return pending
+				calls.append(ToolCall(id=tc["id"], name=fn["name"], arguments=json.loads(arguments)))
+		return calls
 
 	def _build_initial_messages(self, input: str | list[dict[str, Any]]) -> list[dict[str, Any]]:
 		"""For a string, build [system?, user]. For a list, trust the caller and use it as-is —

--- a/flow/tests/test_ai_agent.py
+++ b/flow/tests/test_ai_agent.py
@@ -555,6 +555,34 @@ class TestAgentStreaming(UnitTestCase):
 		self.assertIsInstance(done, Done)
 		self.assertEqual(done.result.output, "picked A")
 
+	def test_run_stream_resume_preserves_prior_tool_calls(self):
+		@tool
+		def lookup() -> str:
+			"""Lookup."""
+			return "result"
+
+		@tool
+		def ask_user(prompt: str) -> Question:
+			"""Ask."""
+			return Question(prompt=prompt, options=["A", "B"])
+
+		agent = Agent(
+			model=FakeModel(
+				[
+					_tool_call("lookup", {}, call_id="c1"),
+					_tool_call("ask_user", {"prompt": "Which?"}, call_id="c2"),
+				]
+			),
+			tools=[lookup, ask_user],
+		)
+		paused = list(agent.run("look then ask", stream=True))[-1].result
+		self.assertEqual([c.name for c in paused.tool_calls], ["lookup"])
+
+		agent.model = FakeModel([_final("done")], streams=[["done"]])
+		done = list(agent.resume(paused.messages, {"c2": "A"}, stream=True))[-1]
+
+		self.assertEqual([c.name for c in done.result.tool_calls], ["lookup", "ask_user"])
+
 
 class TestAgentConfirmation(UnitTestCase):
 	def _danger_tool(self):
@@ -652,6 +680,32 @@ class TestAgentConfirmation(UnitTestCase):
 		payload = json.loads(tool_message["content"])
 		self.assertEqual(payload["status"], "redirect")
 		self.assertEqual(payload["user_feedback"], "use /tmp/y instead")
+
+	def test_resume_preserves_tool_calls_from_before_the_pause(self):
+		write_file, calls = self._danger_tool()
+
+		@tool
+		def read_file(path: str) -> str:
+			"""Read a file."""
+			return "contents"
+
+		model = FakeModel(
+			[
+				_tool_call("read_file", {"path": "/tmp/a"}, call_id="c1"),
+				_tool_call("write_file", {"path": "/tmp/x", "body": "hi"}, call_id="c2"),
+			]
+		)
+		agent = Agent(model=model, tools=[read_file, write_file])
+
+		paused = agent.run("read then write")
+		self.assertEqual([c.name for c in paused.tool_calls], ["read_file"])
+
+		agent.model = FakeModel([_final("done")])
+		resumed = agent.resume(paused.messages, {"c2": "Approve"})
+
+		self.assertEqual(calls, [{"path": "/tmp/x", "body": "hi"}])  # confirmation ran
+		# Both the pre-pause call and the just-approved call survive on the resumed result.
+		self.assertEqual([c.name for c in resumed.tool_calls], ["read_file", "write_file"])
 
 
 class TestQuestion(UnitTestCase):


### PR DESCRIPTION
When a run paused for confirmation and then resumed, `AIRun.tool_calls` would only contain calls made *after* the resume — losing all pre-pause calls and the just-approved call. `iterations` and `usage` were also overwritten with the resume segment only.

**Root cause:** `_loop_stream` started with an empty `executed_calls` list on resume, and `apply_result` overwrote counters instead of accumulating them.

**Fix:** Seed `executed_calls` from the already-answered calls in the transcript before entering the continuation loop. Accumulate `iterations` and `usage` in `apply_result` since resume calls it on the same run doc.