### PR TITLE
feat(ai_run): store reference doctype and name for trigger-fired runs

### DIFF
--- a/flow/ai/doctype/ai_agent/ai_agent.py
+++ b/flow/ai/doctype/ai_agent/ai_agent.py
@@ -112,6 +112,8 @@ class AIAgent(Document):
 		session: str | None = None,
 		source: str = "Manual",
 		trigger: str | None = None,
+		reference_doctype: str | None = None,
+		reference_name: str | None = None,
 		stream: bool = False,
 	) -> AIRun | Generator[Event]:
 		"""Run `input` and persist as an AI Run. Convenience wrapper over the session API:
@@ -119,7 +121,14 @@ class AIAgent(Document):
 		from flow.lib.session import load_session, new_session
 
 		convo = load_session(session, agent=self.name) if session else new_session(self)
-		return convo.chat(input, source=source, trigger=trigger, stream=stream)
+		return convo.chat(
+			input,
+			source=source,
+			trigger=trigger,
+			reference_doctype=reference_doctype,
+			reference_name=reference_name,
+			stream=stream,
+		)
 
 	def _snapshot(self, *, model: str | None = None) -> dict[str, Any]:
 		return {

--- a/flow/ai/doctype/ai_run/ai_run.json
+++ b/flow/ai/doctype/ai_run/ai_run.json
@@ -8,6 +8,8 @@
   "session",
   "source",
   "trigger",
+  "reference_doctype",
+  "reference_name",
   "column_break_meta",
   "status",
   "iterations",
@@ -55,6 +57,23 @@
    "in_standard_filter": 1,
    "label": "Trigger",
    "options": "AI Trigger"
+  },
+  {
+   "depends_on": "eval:doc.source === 'Trigger'",
+   "description": "DocType of the document that fired the trigger.",
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference DocType",
+   "options": "DocType"
+  },
+  {
+   "depends_on": "eval:doc.source === 'Trigger'",
+   "description": "Document that fired the trigger.",
+   "fieldname": "reference_name",
+   "fieldtype": "Dynamic Link",
+   "in_standard_filter": 1,
+   "label": "Reference Name",
+   "options": "reference_doctype"
   },
   {
    "fieldname": "column_break_meta",

--- a/flow/ai/doctype/ai_run/ai_run.py
+++ b/flow/ai/doctype/ai_run/ai_run.py
@@ -48,6 +48,8 @@ class AIRun(Document):
 		iterations: DF.Int
 		output: DF.LongText | None
 		questions: DF.JSON | None
+		reference_doctype: DF.Link | None
+		reference_name: DF.DynamicLink | None
 		session: DF.Link
 		source: DF.Literal["Manual", "Trigger"]
 		status: DF.Literal["Running", "Paused", "Completed", "Failed"]
@@ -112,6 +114,8 @@ def create_run(
 	input: str | None,
 	session: str,
 	trigger: str | None = None,
+	reference_doctype: str | None = None,
+	reference_name: str | None = None,
 	config_snapshot: dict[str, Any] | None = None,
 ) -> AIRun:
 	"""Create a new AI Run row in the Running state. `session` is required — every run
@@ -122,6 +126,8 @@ def create_run(
 			"source": source,
 			"input": input,
 			"trigger": trigger,
+			"reference_doctype": reference_doctype,
+			"reference_name": reference_name,
 			"session": session,
 			"config_snapshot": _dump_json(config_snapshot) if config_snapshot else None,
 			"status": "Running",
@@ -137,6 +143,8 @@ def persist_result(
 	input: str | None,
 	session: str,
 	trigger: str | None = None,
+	reference_doctype: str | None = None,
+	reference_name: str | None = None,
 	config_snapshot: dict[str, Any] | None = None,
 ) -> AIRun:
 	"""Convenience: create a row and immediately apply a finished RunResult."""
@@ -145,6 +153,8 @@ def persist_result(
 		input=input,
 		session=session,
 		trigger=trigger,
+		reference_doctype=reference_doctype,
+		reference_name=reference_name,
 		config_snapshot=config_snapshot,
 	)
 	doc.apply_result(result)

--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -104,6 +104,8 @@ class AISession(Document):
 		*,
 		source: str = "Manual",
 		trigger: str | None = None,
+		reference_doctype: str | None = None,
+		reference_name: str | None = None,
 		stream: bool = False,
 	) -> AIRun | Generator[Event]:
 		"""Run one turn and persist it as an AI Run. With `stream=True`, returns an event generator."""
@@ -120,6 +122,8 @@ class AISession(Document):
 			input=input,
 			session=self.name,
 			trigger=trigger,
+			reference_doctype=reference_doctype,
+			reference_name=reference_name,
 			config_snapshot=self._snapshot,
 		)
 

--- a/flow/tests/test_ai_triggers.py
+++ b/flow/tests/test_ai_triggers.py
@@ -242,6 +242,8 @@ class TestFire(IntegrationTestCase):
 		self.assertEqual(session.agent, self.agent.name)
 		self.assertEqual(run.status, "Completed")
 		self.assertIn(todo.name, run.input)
+		self.assertEqual(run.reference_doctype, "ToDo")
+		self.assertEqual(run.reference_name, todo.name)
 
 	def test_fire_skips_disabled_trigger(self):
 		self.trigger.enabled = 0
@@ -291,3 +293,5 @@ class TestFire(IntegrationTestCase):
 		run = frappe.get_doc("AI Run", run_name)
 		self.assertEqual(run.status, "Completed")
 		self.assertEqual(run.trigger, scheduled.name)
+		self.assertIsNone(run.reference_doctype)
+		self.assertIsNone(run.reference_name)

--- a/flow/triggers/triggers.py
+++ b/flow/triggers/triggers.py
@@ -81,7 +81,13 @@ def fire(
 
 	prompt = frappe.render_template(t.prompt_template, {"doc": doc, "now": frappe.utils.now_datetime()})
 	agent_doc = frappe.get_doc("AI Agent", t.agent)
-	run = agent_doc.run(prompt, source="Trigger", trigger=t.name)
+	run = agent_doc.run(
+		prompt,
+		source="Trigger",
+		trigger=t.name,
+		reference_doctype=target_doctype if doc else None,
+		reference_name=target_name if doc else None,
+	)
 	return run.name
 
 


### PR DESCRIPTION
## Summary

- Adds `reference_doctype` (Link → DocType) and `reference_name` (Dynamic Link) fields to **AI Run**
- When a DocType Event trigger fires, the source document is now persisted on the run, making it queryable ("show runs for SO-0001")
- Scheduled triggers leave both fields null
- Threads the two optional kwargs through `fire()` → `AIAgent.run()` → `AISession.chat()` → `create_run()`; manual runs are unaffected

## Test plan

- `test_fire_runs_agent_and_links_trigger` — asserts `reference_doctype`/`reference_name` match the fired document
- `test_fire_scheduled_trigger_without_target` — asserts both are null for scheduled runs