### PR TITLE
feat: link provider on AI Model to skip provider/ prefix

### DIFF
--- a/flow/ai/doctype/ai_model/ai_model.json
+++ b/flow/ai/doctype/ai_model/ai_model.json
@@ -9,6 +9,7 @@
   "title",
   "enabled",
   "section_break_config",
+  "provider",
   "model_id",
   "api_key",
   "base_url",
@@ -35,7 +36,14 @@
    "fieldtype": "Section Break"
   },
   {
-   "description": "LiteLLM model identifier in <code>provider/model</code> form, e.g. <code>anthropic/claude-sonnet-4-6</code>, <code>openai/gpt-4.1</code>, <code>gemini/gemini-2.0-flash</code>, <code>ollama/llama3.1</code>",
+   "description": "Optional. Pick a provider to skip typing the <code>provider/</code> prefix in Model ID. Leave empty if Model ID already includes the provider.",
+   "fieldname": "provider",
+   "fieldtype": "Link",
+   "label": "Provider",
+   "options": "AI Provider"
+  },
+  {
+   "description": "LiteLLM model identifier. With a Provider linked, enter just the model (e.g. <code>claude-sonnet-4-6</code>); otherwise use <code>provider/model</code> form, e.g. <code>anthropic/claude-sonnet-4-6</code>, <code>openai/gpt-4.1</code>, <code>ollama/llama3.1</code>",
    "fieldname": "model_id",
    "fieldtype": "Data",
    "in_list_view": 1,

--- a/flow/ai/doctype/ai_model/ai_model.py
+++ b/flow/ai/doctype/ai_model/ai_model.py
@@ -30,11 +30,13 @@ class AIModel(Document):
 		enabled: DF.Check
 		model_id: DF.Data
 		params: DF.JSON | None
+		provider: DF.Link | None
 		title: DF.Data
 	# end: auto-generated types
 
 	def validate(self):
 		self._normalize()
+		self._apply_provider()
 		self._validate_model_id()
 		self._validate_base_url()
 		self._validate_params()
@@ -54,6 +56,15 @@ class AIModel(Document):
 				self.set(field, value.strip())
 		if isinstance(self.api_key, str):
 			self.api_key = self.api_key.strip()
+
+	def _apply_provider(self):
+		# A linked provider lets the user enter just the model; compose the
+		# canonical provider/model id. Idempotent if the prefix is already present.
+		if not self.provider:
+			return
+		prefix = f"{self.provider}/"
+		if self.model_id and not self.model_id.startswith(prefix):
+			self.model_id = prefix + self.model_id
 
 	def _validate_model_id(self):
 		if not MODEL_ID_PATTERN.match(self.model_id or ""):

--- a/flow/ai/doctype/ai_model/test_ai_model.py
+++ b/flow/ai/doctype/ai_model/test_ai_model.py
@@ -54,6 +54,37 @@ class TestAIModelValidation(IntegrationTestCase):
 			doc.insert()
 
 
+class TestAIModelProvider(IntegrationTestCase):
+	def setUp(self):
+		if not frappe.db.exists("AI Provider", "anthropic"):
+			frappe.get_doc({"doctype": "AI Provider", "provider": "anthropic"}).insert()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_linked_provider_composes_model_id(self):
+		doc = frappe.get_doc(_model(provider="anthropic", model_id="claude-sonnet-4-6")).insert()
+
+		self.assertEqual(doc.model_id, "anthropic/claude-sonnet-4-6")
+
+	def test_compose_is_idempotent_for_prefixed_model_id(self):
+		doc = frappe.get_doc(_model(provider="anthropic", model_id="anthropic/claude-sonnet-4-6")).insert()
+
+		self.assertEqual(doc.model_id, "anthropic/claude-sonnet-4-6")
+
+	def test_resave_does_not_double_prefix(self):
+		doc = frappe.get_doc(_model(provider="anthropic", model_id="claude-sonnet-4-6")).insert()
+		doc.save()
+
+		self.assertEqual(doc.model_id, "anthropic/claude-sonnet-4-6")
+
+	def test_full_model_id_without_provider_still_works(self):
+		doc = frappe.get_doc(_model(model_id="openai/gpt-4o-mini")).insert()
+
+		self.assertFalse(doc.provider)
+		self.assertEqual(doc.model_id, "openai/gpt-4o-mini")
+
+
 class TestAIModelBaseURL(IntegrationTestCase):
 	def tearDown(self):
 		frappe.db.rollback()


### PR DESCRIPTION
Adds an optional Provider link field to AI Model so users don't have to type `provider/` manually in Model ID.

## What changed
- New optional `Provider` Link field (→ AI Provider) on the AI Model form.
- On save, if a provider is linked and Model ID doesn't already have the prefix, it is composed automatically (e.g. `claude-sonnet-4-6` → `anthropic/claude-sonnet-4-6`). Idempotent — re-saving never double-prefixes.
- Backward compatible: leave Provider empty and enter the full `provider/model` form as before — no change to existing models.

## What didn't change
`model_id` remains the canonical litellm string. All downstream consumers (Model init, credential resolution, test connection, agent snapshot) are untouched.