### PR TITLE
feat: log settings support for AI Session cleanup

### DIFF
--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -62,6 +62,17 @@ class AISession(Document):
 				title=_("Agent Locked"),
 			)
 
+	@staticmethod
+	def clear_old_logs(days=30):
+		"""Delete sessions idle for `days`, along with their AI Runs and transcript rows.
+		Age is last activity (modified), so an actively-used session is never purged."""
+		cutoff = frappe.utils.add_days(frappe.utils.now(), -days)
+		sessions = frappe.get_all("AI Session", filters={"modified": ["<", cutoff]}, pluck="name")
+		for batch in frappe.utils.create_batch(sessions, 100):
+			frappe.db.delete("AI Run", {"session": ["in", batch]})
+			frappe.db.delete("AI Session Message", {"parent": ["in", batch]})
+			frappe.db.delete("AI Session", {"name": ["in", batch]})
+
 	def transcript(self) -> list[dict[str, Any]]:
 		"""Return the conversation history in OpenAI message format."""
 		out: list[dict[str, Any]] = []

--- a/flow/ai/doctype/ai_session/test_ai_session.py
+++ b/flow/ai/doctype/ai_session/test_ai_session.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from flow.ai.doctype.ai_session.ai_session import derive_title
+from flow.ai.doctype.ai_session.ai_session import AISession, derive_title
 
 
 class TestAISession(IntegrationTestCase):
@@ -60,6 +60,39 @@ class TestAISession(IntegrationTestCase):
 		doc.agent = other_agent.name
 		with self.assertRaisesRegex(frappe.ValidationError, "Cannot change the agent"):
 			doc.save(ignore_permissions=True)
+
+
+class TestClearOldLogs(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _session_with_run(self, *, age_days: int) -> str:
+		session = frappe.get_doc({"doctype": "AI Session", "title": "chat"})
+		session.append("messages", {"role": "user", "content": "hi"})
+		session.insert(ignore_permissions=True)
+		run = frappe.get_doc(
+			{"doctype": "AI Run", "session": session.name, "source": "Manual", "status": "Completed"}
+		).insert(ignore_permissions=True)
+		old = frappe.utils.add_days(frappe.utils.now(), -age_days)
+		frappe.db.set_value("AI Session", session.name, "modified", old, update_modified=False)
+		return session.name, run.name
+
+	def test_old_session_and_linked_run_and_messages_are_purged(self):
+		old_session, old_run = self._session_with_run(age_days=100)
+
+		AISession.clear_old_logs(days=30)
+
+		self.assertFalse(frappe.db.exists("AI Session", old_session))
+		self.assertFalse(frappe.db.exists("AI Run", old_run))
+		self.assertEqual(frappe.db.count("AI Session Message", {"parent": old_session}), 0)
+
+	def test_recent_session_is_kept(self):
+		recent_session, recent_run = self._session_with_run(age_days=1)
+
+		AISession.clear_old_logs(days=30)
+
+		self.assertTrue(frappe.db.exists("AI Session", recent_session))
+		self.assertTrue(frappe.db.exists("AI Run", recent_run))
 
 
 class TestDeriveTitle(IntegrationTestCase):

--- a/flow/hooks.py
+++ b/flow/hooks.py
@@ -23,6 +23,10 @@ doc_events = {
 # doc. The incremental sweep removes the orphaned chunk afterwards.
 ignore_links_on_delete = ["AI Knowledge Chunk"]
 
+default_log_clearing_doctypes = {
+	"AI Session": 90,
+}
+
 scheduler_events = {
 	"daily": [
 		"flow.knowledge.ingest.sync_due_sources",


### PR DESCRIPTION
## Summary
- Implements `clear_old_logs` on `AI Session`, cascading to linked `AI Run` records and `AI Session Message` child rows
- Registers `AI Session` in `default_log_clearing_doctypes` (90-day default) so Log Settings auto-adds it and the scheduled cleanup runs it
- Age is based on `modified` (not `creation`) so actively-used sessions are never purged mid-life

## Test plan
- `test_old_session_and_linked_run_and_messages_are_purged`: session, its run, and messages are all deleted when older than threshold
- `test_recent_session_is_kept`: recent sessions are untouched