### PR TITLE
feat: panel UX improvements — fullscreen, wide-layout centering, perf

### DIFF
--- a/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.json
+++ b/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.json
@@ -14,7 +14,6 @@
   "file",
   "url",
   "reference_doctype",
-  "column_break_doctype",
   "filters",
   "content_fields",
   "auto_sync",
@@ -92,10 +91,6 @@
    "label": "Reference DocType",
    "mandatory_depends_on": "eval:doc.source_type == \"DocType\"",
    "options": "DocType"
-  },
-  {
-   "fieldname": "column_break_doctype",
-   "fieldtype": "Column Break"
   },
   {
    "depends_on": "eval:doc.source_type == \"DocType\"",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,7 +5,10 @@ import MessageList from "./components/MessageList.vue";
 import Composer from "./components/Composer.vue";
 import { useStore } from "./store";
 
-const props = defineProps({ onClose: { type: Function, default: null } });
+const props = defineProps({
+	onClose: { type: Function, default: null },
+	onToggleFullscreen: { type: Function, default: null },
+});
 const { loadInitial } = useStore();
 
 onMounted(loadInitial);
@@ -15,7 +18,10 @@ onMounted(loadInitial);
 	<div
 		class="flow-panel flex h-full flex-col border-l border-outline-gray-2 bg-surface-white text-ink-gray-9"
 	>
-		<PanelHeader @close="props.onClose && props.onClose()" />
+		<PanelHeader
+			:on-toggle-fullscreen="props.onToggleFullscreen"
+			@close="props.onClose && props.onClose()"
+		/>
 		<MessageList />
 		<Composer />
 	</div>

--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -65,7 +65,7 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 <template>
 	<div class="border-t border-outline-gray-1 px-4 pb-3.5 pt-2.5">
 		<div
-			class="flow-composer flex flex-col gap-1.5 rounded-xl border border-outline-gray-2 bg-surface-white px-2.5 py-2 shadow-sm"
+			class="flow-composer mx-auto flex w-full max-w-3xl flex-col gap-1.5 rounded-xl border border-outline-gray-2 bg-surface-white px-2.5 py-2 shadow-sm"
 		>
 			<textarea
 				ref="el"

--- a/frontend/src/components/MarkdownText.vue
+++ b/frontend/src/components/MarkdownText.vue
@@ -1,17 +1,22 @@
 <script setup>
 import { ref, watch, onUnmounted } from "vue";
 
-// Renders streamed assistant text as markdown. Parsing is coalesced to one call
-// per animation frame so a fast token stream can't trigger a parse per token.
+// Renders streamed assistant text as markdown. Parsing the full accumulated
+// string is O(n), so doing it per token (or per frame) is O(n²) over a long
+// response. Instead we throttle to one parse per THROTTLE_MS, with a guaranteed
+// trailing parse so the final text always renders in full.
 // Takes the whole part (not part.text) so the parent's render doesn't depend on
 // the streaming text — only this component reacts to each token.
 const props = defineProps({ part: { type: Object, required: true } });
 
+const THROTTLE_MS = 100;
 const html = ref("");
-let frame = 0;
+let timer = 0;
+let last = 0;
 
 function render() {
-	frame = 0;
+	timer = 0;
+	last = performance.now();
 	const raw = props.part.text || "";
 	let out = window.frappe?.markdown ? frappe.markdown(raw) : escapeHtml(raw);
 	// Let a wide table scroll in its own box instead of widening the panel.
@@ -21,8 +26,11 @@ function render() {
 }
 
 function schedule() {
-	if (frame) return;
-	frame = requestAnimationFrame(render);
+	// A pending timer will read the freshest text when it fires, so coalesce.
+	if (timer) return;
+	const elapsed = performance.now() - last;
+	if (elapsed >= THROTTLE_MS) render();
+	else timer = setTimeout(render, THROTTLE_MS - elapsed);
 }
 
 function escapeHtml(s) {
@@ -30,7 +38,7 @@ function escapeHtml(s) {
 }
 
 watch(() => props.part.text, schedule, { immediate: true });
-onUnmounted(() => frame && cancelAnimationFrame(frame));
+onUnmounted(() => timer && clearTimeout(timer));
 </script>
 
 <template>

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -32,19 +32,21 @@ watch(scrollTick, () => {
 <template>
 	<div
 		ref="el"
-		class="flow-scrollbar flex flex-1 flex-col gap-5 overflow-y-auto px-4 py-3"
+		class="flow-scrollbar flex flex-1 flex-col overflow-y-auto px-4 py-3"
 		@scroll="onScroll"
 	>
-		<EmptyState
-			v-if="!messages.length"
-			:setup="needsSetup"
-			:has-models="models.length > 0"
-			:has-agents="agents.length > 0"
-		/>
+		<div class="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-5">
+			<EmptyState
+				v-if="!messages.length"
+				:setup="needsSetup"
+				:has-models="models.length > 0"
+				:has-agents="agents.length > 0"
+			/>
 
-		<template v-for="msg in messages" :key="msg.id">
-			<UserMessage v-if="msg.role === 'user'" :content="msg.content" />
-			<AssistantMessage v-else :message="msg" />
-		</template>
+			<template v-for="msg in messages" :key="msg.id">
+				<UserMessage v-if="msg.role === 'user'" :content="msg.content" />
+				<AssistantMessage v-else :message="msg" />
+			</template>
+		</div>
 	</div>
 </template>

--- a/frontend/src/components/PanelHeader.vue
+++ b/frontend/src/components/PanelHeader.vue
@@ -5,8 +5,9 @@ import { Button, FeatherIcon } from "@/lib/ui";
 import { useStore } from "@/store";
 import { __ } from "@/lib/translate";
 
+const props = defineProps({ onToggleFullscreen: { type: Function, default: null } });
 const emit = defineEmits(["close"]);
-const { recentSessions, switchSession, newChat } = useStore();
+const { recentSessions, switchSession, newChat, fullscreen } = useStore();
 </script>
 
 <template>
@@ -20,6 +21,18 @@ const { recentSessions, switchSession, newChat } = useStore();
 		<Button variant="ghost" :title="__('New chat')" @click="newChat">
 			<template #icon
 				><FeatherIcon name="plus" :stroke-width="2" class="h-3.5 w-3.5"
+			/></template>
+		</Button>
+		<Button
+			variant="ghost"
+			:title="fullscreen ? __('Exit full screen') : __('Full screen')"
+			@click="props.onToggleFullscreen && props.onToggleFullscreen()"
+		>
+			<template #icon
+				><FeatherIcon
+					:name="fullscreen ? 'minimize' : 'maximize'"
+					:stroke-width="2"
+					class="h-3.5 w-3.5"
 			/></template>
 		</Button>
 		<Button variant="ghost" :title="__('Close (Ctrl+M)')" @click="emit('close')">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,8 +1,10 @@
 import { createApp } from "vue";
 import App from "@/App.vue";
+import { useStore } from "@/store";
 import "@/index.css";
 
 const PANEL_WIDTH = 420;
+const MIN_WIDTH = 360;
 
 // Slide-in overlay panel injected into the Frappe desk. The Vue app (with real
 // frappe-ui components) mounts inside #flow-root; all bundle CSS is scoped to
@@ -31,8 +33,54 @@ class FlowPanel {
 		});
 		document.body.appendChild(this.root);
 
-		this.app = createApp(App, { onClose: () => this.hide() });
+		this.store = useStore();
+		this.app = createApp(App, {
+			onClose: () => this.hide(),
+			onToggleFullscreen: () => this.toggleFullscreen(),
+		});
 		this.app.mount(this.root);
+
+		this._addResizeHandle();
+	}
+
+	// Thin grab strip on the panel's left edge. Dragging it changes the panel
+	// width (anchored to the right). Appended after mount so Vue's render
+	// doesn't clobber it.
+	_addResizeHandle() {
+		const handle = document.createElement("div");
+		Object.assign(handle.style, {
+			position: "absolute",
+			top: "0",
+			left: "0",
+			width: "6px",
+			height: "100%",
+			cursor: "ew-resize",
+			zIndex: "10",
+		});
+		this.root.appendChild(handle);
+
+		const onMove = (e) => {
+			const max = window.innerWidth - 80;
+			const width = Math.min(max, Math.max(MIN_WIDTH, window.innerWidth - e.clientX));
+			this.root.style.width = `${width}px`;
+			// A manual resize takes the panel out of fullscreen; keep the header icon honest.
+			this.store.fullscreen.value = false;
+		};
+		const onUp = () => {
+			document.removeEventListener("mousemove", onMove);
+			document.removeEventListener("mouseup", onUp);
+			document.body.style.userSelect = "";
+			this.root.style.transition = this._savedTransition;
+		};
+		handle.addEventListener("mousedown", (e) => {
+			e.preventDefault();
+			// Drop the width transition while dragging so it tracks the cursor.
+			this._savedTransition = this.root.style.transition;
+			this.root.style.transition = "none";
+			document.body.style.userSelect = "none";
+			document.addEventListener("mousemove", onMove);
+			document.addEventListener("mouseup", onUp);
+		});
 	}
 
 	// Mirror the desk's light/dark theme onto the panel root so scoped tokens
@@ -70,6 +118,19 @@ class FlowPanel {
 
 	toggle() {
 		this.visible ? this.hide() : this.show();
+	}
+
+	// Expand the panel to the full viewport width, or restore its previous
+	// width. State lives in the store so the header icon tracks it reactively.
+	toggleFullscreen() {
+		const next = !this.store.fullscreen.value;
+		this.store.fullscreen.value = next;
+		if (next) {
+			this._savedWidth = this.root.style.width;
+			this.root.style.width = "100vw";
+		} else {
+			this.root.style.width = this._savedWidth || `${PANEL_WIDTH}px`;
+		}
 	}
 }
 

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -21,6 +21,7 @@ const runName = ref(null);
 const messages = ref([]);
 const sending = ref(false);
 const loaded = ref(false);
+const fullscreen = ref(false);
 
 // Bumped whenever new content arrives / focus is wanted; views watch & react.
 const scrollTick = ref(0);
@@ -317,6 +318,7 @@ export function useStore() {
 		messages,
 		sending,
 		loaded,
+		fullscreen,
 		scrollTick,
 		focusTick,
 		// derived


### PR DESCRIPTION
## Summary

- Fullscreen toggle button in panel header (four-corner icon); state syncs with drag resize so the icon stays accurate
- Message list and composer cap at `max-w-3xl` and center when the panel is wider — matches Claude/Gemini layout
- Fix AI Knowledge Source doctype column break so Filters/Content Fields render below Reference DocType
- Throttle markdown re-parse to 100ms during streaming (was per-frame → O(n²) on long responses)