### PR TITLE
feat: autocomplete Model ID from litellm provider models

### DIFF
--- a/flow/ai/doctype/ai_model/ai_model.js
+++ b/flow/ai/doctype/ai_model/ai_model.js
@@ -3,6 +3,8 @@
 
 frappe.ui.form.on("AI Model", {
 	refresh(frm) {
+		load_provider_models(frm);
+
 		if (frm.is_new()) return;
 
 		frm.add_custom_button(__("Test Connection"), async () => {
@@ -29,4 +31,23 @@ frappe.ui.form.on("AI Model", {
 			}
 		});
 	},
+
+	provider(frm) {
+		load_provider_models(frm);
+	},
 });
+
+function load_provider_models(frm) {
+	const field = frm.fields_dict.model_id;
+	// Suggestions are hints, never a restriction — allow any typed model_id.
+	field.df.ignore_validation = true;
+	if (!frm.doc.provider) {
+		field.set_data([]);
+		return;
+	}
+	frappe.call({
+		method: "flow.ai.doctype.ai_model.ai_model.get_provider_models",
+		args: { provider: frm.doc.provider },
+		callback: ({ message }) => field.set_data(message || []),
+	});
+}

--- a/flow/ai/doctype/ai_model/ai_model.json
+++ b/flow/ai/doctype/ai_model/ai_model.json
@@ -43,9 +43,9 @@
    "options": "AI Provider"
   },
   {
-   "description": "LiteLLM model identifier. With a Provider linked, enter just the model (e.g. <code>claude-sonnet-4-6</code>); otherwise use <code>provider/model</code> form, e.g. <code>anthropic/claude-sonnet-4-6</code>, <code>openai/gpt-4.1</code>, <code>ollama/llama3.1</code>",
+   "description": "LiteLLM model identifier. With a Provider linked, pick or type just the model (e.g. <code>claude-sonnet-4-6</code>); otherwise use <code>provider/model</code> form, e.g. <code>anthropic/claude-sonnet-4-6</code>, <code>openai/gpt-4.1</code>, <code>ollama/llama3.1</code>",
    "fieldname": "model_id",
-   "fieldtype": "Data",
+   "fieldtype": "Autocomplete",
    "in_list_view": 1,
    "label": "Model ID",
    "reqd": 1

--- a/flow/ai/doctype/ai_model/ai_model.py
+++ b/flow/ai/doctype/ai_model/ai_model.py
@@ -145,3 +145,13 @@ class AIModel(Document):
 			frappe.throw(str(e)[:500] or type(e).__name__, title=_(type(e).__name__))
 
 		return {"ok": True, "message": _("Connection OK")}
+
+
+@frappe.whitelist()
+def get_provider_models(provider: str | None = None) -> list[str]:
+	if not provider:
+		return []
+
+	import litellm
+
+	return sorted(litellm.models_by_provider.get(provider.strip().lower(), set()))


### PR DESCRIPTION
## Summary

- Changes `model_id` field from `Data` to `Autocomplete` in the AI Model doctype
- Adds a whitelisted `get_provider_models(provider)` method that returns sorted models from `litellm.models_by_provider` for a given provider
- On form load and provider change, fetches and populates the autocomplete suggestions; `ignore_validation` is set at runtime so free-typing any model ID still works

## Test plan

- [ ] Select a provider (e.g. `anthropic`) — Model ID field should show a dropdown with that provider's models
- [ ] Change provider — dropdown should update
- [ ] Clear provider — no dropdown, type `provider/model` freely
- [ ] Type a custom model ID not in the list — value should not be cleared on blur
- [ ] Save with a valid model ID — should pass existing `_validate_model_id` / `_validate_provider_known` checks