### PR TITLE
feat: raise assistant iteration limits

### DIFF
--- a/flow/ai/doctype/ai_agent/ai_agent.py
+++ b/flow/ai/doctype/ai_agent/ai_agent.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 	from flow.lib.tool import Tool
 
 DEFAULT_TOOL_SLUGS = ("describe", "read", "execute")
-DEFAULT_MAX_ITERATIONS = 10
+DEFAULT_MAX_ITERATIONS = 20
 
 
 class AIAgent(Document):

--- a/flow/ai/doctype/ai_agent/test_ai_agent.py
+++ b/flow/ai/doctype/ai_agent/test_ai_agent.py
@@ -97,7 +97,7 @@ class TestAIAgentAssemble(IntegrationTestCase):
 
 		runtime = self.agent_doc.assemble()
 
-		self.assertEqual(runtime.max_iterations, 10)
+		self.assertEqual(runtime.max_iterations, 20)
 
 	def test_assemble_throws_when_agent_disabled(self):
 		self.agent_doc.enabled = 0

--- a/flow/assistant/assistant.py
+++ b/flow/assistant/assistant.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import frappe
 
 ASSISTANT_AGENT_TITLE = "Assistant"
+ASSISTANT_MAX_ITERATIONS = 40
 
 ASSISTANT_INSTRUCTIONS = (
 	"You are a Frappe assistant working inside a Frappe site.\n\n"
@@ -71,6 +72,7 @@ def sync_builtin_assistant(model: str | None = None) -> None:
 				"title": ASSISTANT_AGENT_TITLE,
 				"model": model_name,
 				"instructions": ASSISTANT_INSTRUCTIONS,
+				"max_iterations": ASSISTANT_MAX_ITERATIONS,
 				"tools": [{"tool": slug} for slug in tool_slugs],
 				"enabled": 1,
 				"is_system_generated": 1,


### PR DESCRIPTION
Raises iteration limits for the builtin assistant and the AI Agent default.

- Builtin **Assistant** agent now created with `max_iterations = 40`. Set only on create — `sync_builtin_assistant` no longer overwrites it on migrate, so a customized limit (or any other system-generated agent's limit) is preserved.
- AI Agent doctype default (`DEFAULT_MAX_ITERATIONS`) bumped from 10 to 20 — the fallback when an agent has no explicit `max_iterations`.
- Updated the assemble-default test to assert 20.