### PR TITLE
feat: chat file attachments with token-budget routing and ephemeral retrieval

### DIFF
--- a/flow/ai/doctype/ai_model/ai_model.json
+++ b/flow/ai/doctype/ai_model/ai_model.json
@@ -11,6 +11,7 @@
   "section_break_config",
   "provider",
   "model_id",
+  "context_window",
   "api_key",
   "base_url",
   "section_break_params",
@@ -49,6 +50,13 @@
    "in_list_view": 1,
    "label": "Model ID",
    "reqd": 1
+  },
+  {
+   "description": "Max input tokens. Auto-detected from the model on save when left empty; override if your provider differs. 0 = unknown.",
+   "fieldname": "context_window",
+   "fieldtype": "Int",
+   "label": "Context Window",
+   "non_negative": 1
   },
   {
    "description": "API key for the provider named in the Model ID. Leave empty for local servers (Ollama, LM Studio) that don't require authentication.",

--- a/flow/ai/doctype/ai_model/ai_model.py
+++ b/flow/ai/doctype/ai_model/ai_model.py
@@ -104,10 +104,10 @@ class AIModel(Document):
 			)
 
 	def _resolve_context_window(self):
-		# Auto-detect when empty or when the model changed; a manual value is kept as
-		# long as the model is unchanged. If litellm doesn't know the model, leave the
-		# existing value (callers fall back to a default when it's 0).
-		if self.context_window and not self.has_value_changed("model_id"):
+		# Auto-detect only when empty, or when the model changed on an existing doc. A value
+		# set by hand is kept — including one provided at creation. If litellm doesn't know
+		# the model, leave the existing value (callers fall back to a default when it's 0).
+		if self.context_window and (self.is_new() or not self.has_value_changed("model_id")):
 			return
 		self.context_window = _detect_context_window(self.model_id) or self.context_window or 0
 

--- a/flow/ai/doctype/ai_model/ai_model.py
+++ b/flow/ai/doctype/ai_model/ai_model.py
@@ -27,6 +27,7 @@ class AIModel(Document):
 
 		api_key: DF.Password | None
 		base_url: DF.Data | None
+		context_window: DF.Int
 		enabled: DF.Check
 		model_id: DF.Data
 		params: DF.JSON | None
@@ -41,6 +42,7 @@ class AIModel(Document):
 		self._validate_base_url()
 		self._validate_params()
 		self._validate_provider_known()
+		self._resolve_context_window()
 
 	def after_insert(self):
 		if not self.enabled:
@@ -101,6 +103,14 @@ class AIModel(Document):
 				title=_("Reserved Params"),
 			)
 
+	def _resolve_context_window(self):
+		# Auto-detect when empty or when the model changed; a manual value is kept as
+		# long as the model is unchanged. If litellm doesn't know the model, leave the
+		# existing value (callers fall back to a default when it's 0).
+		if self.context_window and not self.has_value_changed("model_id"):
+			return
+		self.context_window = _detect_context_window(self.model_id) or self.context_window or 0
+
 	def _validate_provider_known(self):
 		try:
 			import litellm
@@ -145,6 +155,17 @@ class AIModel(Document):
 			frappe.throw(str(e)[:500] or type(e).__name__, title=_(type(e).__name__))
 
 		return {"ok": True, "message": _("Connection OK")}
+
+
+def _detect_context_window(model_id: str) -> int:
+	"""Max input tokens for `model_id` per litellm, or 0 if unknown/unmapped."""
+	import litellm
+
+	try:
+		info = litellm.get_model_info(model_id)
+	except Exception:
+		return 0
+	return int(info.get("max_input_tokens") or 0)
 
 
 @frappe.whitelist()

--- a/flow/ai/doctype/ai_model/test_ai_model.py
+++ b/flow/ai/doctype/ai_model/test_ai_model.py
@@ -2,9 +2,12 @@
 # See license.txt
 
 from typing import Any
+from unittest.mock import patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
+
+from flow.ai.doctype.ai_model.ai_model import _detect_context_window
 
 
 def _model(**overrides: Any) -> dict:
@@ -136,3 +139,52 @@ class TestAIModelParams(IntegrationTestCase):
 				doc = frappe.get_doc(_model(params=f'{{"{reserved}": "x"}}'))
 				with self.assertRaisesRegex(frappe.ValidationError, "reserved keys"):
 					doc.insert()
+
+
+class TestContextWindow(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_detect_returns_max_input_tokens(self):
+		with patch("litellm.get_model_info", return_value={"max_input_tokens": 200000}):
+			self.assertEqual(_detect_context_window("anthropic/claude-x"), 200000)
+
+	def test_detect_unmapped_model_returns_zero(self):
+		with patch("litellm.get_model_info", side_effect=Exception("not mapped")):
+			self.assertEqual(_detect_context_window("vendor/unknown"), 0)
+
+	def test_detect_missing_field_returns_zero(self):
+		with patch("litellm.get_model_info", return_value={}):
+			self.assertEqual(_detect_context_window("vendor/x"), 0)
+
+	def test_auto_fills_when_empty_on_insert(self):
+		with patch("litellm.get_model_info", return_value={"max_input_tokens": 128000}):
+			doc = frappe.get_doc(_model()).insert()
+		self.assertEqual(doc.context_window, 128000)
+
+	def test_manual_value_preserved_when_model_unchanged(self):
+		with patch("litellm.get_model_info", return_value={"max_input_tokens": 128000}):
+			doc = frappe.get_doc(_model(context_window=50000)).insert()
+			self.assertEqual(doc.context_window, 50000)  # manual value kept, not overwritten
+			doc.title = "Renamed"
+			doc.save()
+		self.assertEqual(doc.context_window, 50000)
+
+	def test_redetects_on_model_id_change(self):
+		with patch("litellm.get_model_info", return_value={"max_input_tokens": 128000}):
+			doc = frappe.get_doc(_model(context_window=50000)).insert()
+		# New model id (valid provider) -> re-detect, overriding the prior value.
+		with patch("litellm.get_model_info", return_value={"max_input_tokens": 1000000}) as m:
+			doc.model_id = "anthropic/claude-x"
+			doc.save()
+		m.assert_called()
+		self.assertEqual(doc.context_window, 1000000)
+
+	def test_keeps_existing_when_new_model_unmapped(self):
+		with patch("litellm.get_model_info", return_value={"max_input_tokens": 128000}):
+			doc = frappe.get_doc(_model(context_window=50000)).insert()
+		# Valid provider, but litellm can't map the model -> keep the prior value.
+		with patch("litellm.get_model_info", side_effect=Exception("not mapped")):
+			doc.model_id = "anthropic/made-up-model-xyz"
+			doc.save()
+		self.assertEqual(doc.context_window, 50000)

--- a/flow/ai/doctype/ai_session/ai_session.json
+++ b/flow/ai/doctype/ai_session/ai_session.json
@@ -9,7 +9,8 @@
   "agent",
   "model",
   "section_break_transcript",
-  "messages"
+  "messages",
+  "attachments"
  ],
  "fields": [
   {
@@ -49,6 +50,14 @@
    "fieldtype": "Table",
    "label": "Messages",
    "options": "AI Session Message",
+   "read_only": 1
+  },
+  {
+   "description": "Files attached across all runs in this conversation.",
+   "fieldname": "attachments",
+   "fieldtype": "Table",
+   "label": "Attachments",
+   "options": "AI Session Attachment",
    "read_only": 1
   }
  ],

--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -30,9 +30,11 @@ class AISession(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		from flow.ai.doctype.ai_session_attachment.ai_session_attachment import AISessionAttachment
 		from flow.ai.doctype.ai_session_message.ai_session_message import AISessionMessage
 
 		agent: DF.Link | None
+		attachments: DF.Table[AISessionAttachment]
 		messages: DF.Table[AISessionMessage]
 		model: DF.Link | None
 		title: DF.Data | None

--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -20,6 +20,17 @@ TITLE_MAX_LENGTH = 80
 # A "Running" run older than this is treated as abandoned and no longer blocks the session.
 RUNNING_STALE_SECONDS = 300
 
+# Attachment routing. A file whose text exceeds RETRIEVAL_FRACTION of the model's
+# context window is too big to inline every turn, so it is chunked and retrieved
+# instead. Tokens are estimated from characters (no per-turn tokenizer cost).
+DEFAULT_CONTEXT_WINDOW = 128000
+CHARS_PER_TOKEN = 4
+RETRIEVAL_FRACTION = 0.5
+# Chars reserved (as tokens) for the model's reply when budgeting file content.
+RESERVED_OUTPUT_TOKENS = 4096
+# How many retrieved chunks to inject for the current turn.
+RETRIEVAL_TOP_K = 8
+
 
 class AISession(Document):
 	# begin: auto-generated types
@@ -131,6 +142,7 @@ class AISession(Document):
 			config_snapshot=self._snapshot,
 		)
 		self._persist_turn(input, attachment_data, run.name)
+		self._index_retrieval_attachments(run.name)
 		run_input = self._build_prompt_messages()
 
 		if stream:
@@ -164,6 +176,9 @@ class AISession(Document):
 		if not self.messages and self._runtime.instructions:
 			self.append("messages", {"role": "system", "content": self._runtime.instructions, "run": run})
 		self.append("messages", {"role": "user", "content": input, "run": run})
+
+		threshold = self._attachment_inline_threshold()
+		embeddings_on = _embeddings_configured()
 		for data in attachment_data:
 			self.append(
 				"attachments",
@@ -172,10 +187,61 @@ class AISession(Document):
 					"file_name": data["file_name"],
 					"file_size": data["file_size"],
 					"extracted_text": data["extracted_text"],
+					"mode": _route_attachment(data["extracted_text"], threshold, embeddings_on),
 					"run": run,
 				},
 			)
 		self.save(ignore_permissions=True)
+
+	def _context_window(self) -> int:
+		"""The effective model's context window in tokens (a default when unknown)."""
+		model = (self._snapshot or {}).get("model")
+		return (model and frappe.db.get_value("AI Model", model, "context_window")) or DEFAULT_CONTEXT_WINDOW
+
+	def _attachment_inline_threshold(self) -> int:
+		"""Max characters of file text to inline before switching a file to retrieval."""
+		return int(self._context_window() * CHARS_PER_TOKEN * RETRIEVAL_FRACTION)
+
+	def _file_injection_budget(self) -> int:
+		"""Characters left for file content this turn: the context window minus the reply
+		reservation and the conversation text already in the transcript. Shrinks as the
+		conversation grows, so inline files yield to the dialogue rather than overflow it."""
+		window_chars = self._context_window() * CHARS_PER_TOKEN
+		reserved = RESERVED_OUTPUT_TOKENS * CHARS_PER_TOKEN
+		dialogue = sum(len(m.content or "") for m in self.messages)
+		return max(0, window_chars - reserved - dialogue)
+
+	def _index_retrieval_attachments(self, run: str) -> None:
+		"""Chunk, embed, and store this run's retrieval-mode attachments. On any failure
+		the row is demoted to Inline so the turn still works (file text gets truncated
+		at prompt-build time instead)."""
+		rows = [a for a in self.attachments if a.run == run and a.mode == "Retrieval"]
+		if not rows:
+			return
+
+		from frappe.utils import cint
+
+		from flow.knowledge import attachment_store
+		from flow.knowledge.chunker import chunk_text
+		from flow.knowledge.embedder import embed_texts
+
+		settings = frappe.get_cached_doc("AI Knowledge Settings")
+		for row in rows:
+			try:
+				chunks = chunk_text(
+					row.extracted_text,
+					chunk_size=cint(settings.chunk_size),
+					overlap=cint(settings.chunk_overlap),
+				)
+				if not chunks:
+					row.db_set("mode", "Inline")
+					continue
+				vectors = embed_texts(chunks)
+				attachment_store.ensure_table(cint(settings.embedding_dimension))
+				attachment_store.add(self.name, row.name, chunks, vectors)
+			except Exception:
+				frappe.log_error(title="Chat attachment indexing failed")
+				row.db_set("mode", "Inline")
 
 	def resume(self, answers: dict[str, Any], *, stream: bool = False) -> AIRun | Generator[Event]:
 		"""Resume this session's paused run with the user's answers."""
@@ -208,18 +274,50 @@ class AISession(Document):
 		return run
 
 	def _build_prompt_messages(self) -> list[dict[str, Any]]:
-		"""Transcript as sent to the model: every user turn's content is augmented with the
-		text of the files attached on that turn, so the file stays in context for the whole
-		conversation (matching ChatGPT/Claude/Gemini). The augmentation is ephemeral — stored
-		messages stay clean (the file text lives only in the attachments child table)."""
-		by_run = self._group_attachments_by_run()
+		"""Transcript as sent to the model. Augmentation is ephemeral — stored messages stay
+		clean (file text lives only in the attachments child table):
+
+		- Inline files: full text re-injected on their turn, clamped to the remaining budget.
+		- Retrieval files: a short note marks where each was attached; for the latest user turn
+		  the most relevant chunks (by that turn's query) are injected in place of the full text.
+		"""
+		from flow.knowledge.retriever import retrieve_attachments
+
+		attachments_by_run = self._group_attachments_by_run()
+		last_user_run = self._latest_user_run()
+		query = self._latest_user_content() if any(a.mode == "Retrieval" for a in self.attachments) else None
+		budget = self._file_injection_budget()
+
 		messages: list[dict[str, Any]] = []
 		for row in self.messages:
 			message = _row_to_message(row)
-			if row.role == "user" and row.run in by_run:
-				message["content"] = _inject_file_text(message["content"], by_run[row.run])
+			if row.role == "user":
+				content = message["content"]
+				attachments = attachments_by_run.get(row.run, [])
+				inline = [a for a in attachments if a.mode == "Inline"]
+				retrieval = [a for a in attachments if a.mode == "Retrieval"]
+				if inline:
+					content, budget = _inject_inline_files(content, inline, budget)
+				if retrieval:
+					content = _note_retrieval_files(content, retrieval)
+				if query and row.run == last_user_run:
+					chunks = retrieve_attachments(query, session=self.name, limit=RETRIEVAL_TOP_K)
+					content, budget = _inject_retrieved_chunks(content, chunks, budget)
+				message["content"] = content
 			messages.append(message)
 		return messages
+
+	def _latest_user_run(self) -> str | None:
+		for row in reversed(self.messages):
+			if row.role == "user":
+				return row.run
+		return None
+
+	def _latest_user_content(self) -> str:
+		for row in reversed(self.messages):
+			if row.role == "user":
+				return row.content or ""
+		return ""
 
 	def _group_attachments_by_run(self) -> dict[str, list[Any]]:
 		grouped: dict[str, list[Any]] = {}
@@ -256,6 +354,19 @@ class AISession(Document):
 		)
 
 
+def _embeddings_configured() -> bool:
+	"""Whether an embedding model is set, i.e. retrieval mode is available."""
+	return bool(frappe.get_cached_value("AI Knowledge Settings", "AI Knowledge Settings", "embedding_model"))
+
+
+def _route_attachment(text: str | None, threshold: int, embeddings_on: bool) -> str:
+	"""Inline a file that fits; route an oversized one to retrieval when embeddings are
+	available, else keep it Inline (it is truncated to fit at prompt-build time)."""
+	if len(text or "") <= threshold:
+		return "Inline"
+	return "Retrieval" if embeddings_on else "Inline"
+
+
 def _row_to_message(row) -> dict[str, Any]:
 	"""Convert a stored transcript row to an OpenAI-format message dict."""
 	if row.role == "tool":
@@ -266,15 +377,51 @@ def _row_to_message(row) -> dict[str, Any]:
 	return message
 
 
-def _inject_file_text(content: str | None, attachments: list[Any]) -> str:
-	"""Append attached-file text to a user message, clearly delimited as data for the model."""
-	blocks = [
-		f"--- File: {a.file_name} ---\n{a.extracted_text}\n--- End of file: {a.file_name} ---"
-		for a in attachments
-	]
-	files = "\n\n".join(blocks)
-	body = f"{_('The user attached the following file(s):')}\n\n{files}"
-	return f"{content}\n\n{body}" if content else body
+def _inject_inline_files(content: str | None, attachments: list[Any], budget: int) -> tuple[str, int]:
+	"""Append inline files' full text to a user message, clamped to the shared `budget`.
+	Returns the augmented content and the remaining budget."""
+	blocks = []
+	for a in attachments:
+		text, truncated = _clamp(a.extracted_text or "", budget)
+		budget -= len(text)
+		marker = _("\n\n[File truncated to fit the context window.]") if truncated else ""
+		blocks.append(f"--- File: {a.file_name} ---\n{text}{marker}\n--- End of file: {a.file_name} ---")
+	body = f"{_('The user attached the following file(s):')}\n\n" + "\n\n".join(blocks)
+	return (f"{content}\n\n{body}" if content else body), budget
+
+
+def _note_retrieval_files(content: str | None, attachments: list[Any]) -> str:
+	"""Mark where large (retrieval-mode) files were attached, without their bulk. Their
+	relevant excerpts are injected on the latest turn rather than inline here."""
+	names = ", ".join(a.file_name for a in attachments)
+	note = _("The user attached file(s) (large; relevant excerpts shown below): {0}").format(names)
+	return f"{content}\n\n{note}" if content else note
+
+
+def _inject_retrieved_chunks(
+	content: str | None, chunks: list[dict[str, Any]], budget: int
+) -> tuple[str, int]:
+	"""Append retrieved excerpts to the latest user message, within the remaining budget."""
+	blocks = []
+	for chunk in chunks:
+		text, _truncated = _clamp(chunk["content"], budget)
+		if not text:
+			break
+		budget -= len(text)
+		blocks.append(text)
+	if not blocks:
+		return content or "", budget
+	body = f"{_('Relevant excerpts from the attached file(s):')}\n\n" + "\n\n---\n\n".join(blocks)
+	return (f"{content}\n\n{body}" if content else body), budget
+
+
+def _clamp(text: str, limit: int) -> tuple[str, bool]:
+	"""Return (text capped at `limit` chars, was_truncated)."""
+	if limit <= 0:
+		return "", bool(text)
+	if len(text) <= limit:
+		return text, False
+	return text[:limit], True
 
 
 def derive_title(text: str) -> str:

--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -77,18 +77,7 @@ class AISession(Document):
 
 	def transcript(self) -> list[dict[str, Any]]:
 		"""Return the conversation history in OpenAI message format."""
-		out: list[dict[str, Any]] = []
-		for row in self.messages:
-			message: dict[str, Any] = {"role": row.role}
-			if row.role == "tool":
-				message["tool_call_id"] = row.tool_call_id
-				message["content"] = row.content or ""
-			else:
-				message["content"] = row.content
-				if row.tool_calls:
-					message["tool_calls"] = json.loads(row.tool_calls)
-			out.append(message)
-		return out
+		return [_row_to_message(row) for row in self.messages]
 
 	def append_run_messages(self, new_messages: list[dict[str, Any]], run: str) -> None:
 		"""Append the messages produced by `run` to this session's transcript.
@@ -115,21 +104,23 @@ class AISession(Document):
 		self,
 		input: str,
 		*,
+		attachments: list[str] | None = None,
 		source: str = "Manual",
 		trigger: str | None = None,
 		reference_doctype: str | None = None,
 		reference_name: str | None = None,
 		stream: bool = False,
 	) -> AIRun | Generator[Event]:
-		"""Run one turn and persist it as an AI Run. With `stream=True`, returns an event generator."""
+		"""Run one turn and persist it as an AI Run. `attachments` are File names whose text
+		is injected into this turn's prompt. With `stream=True`, returns an event generator."""
 		from flow.ai.doctype.ai_run.ai_run import create_run, stream_with_persistence
 
 		self.reload()
 		self._assert_not_blocked()
+		attachment_data = self._load_attachments(attachments)
 		if not self.title:
 			self.db_set("title", derive_title(input))
 
-		run_input = self._build_input(input)
 		run = create_run(
 			source=source,
 			input=input,
@@ -139,6 +130,8 @@ class AISession(Document):
 			reference_name=reference_name,
 			config_snapshot=self._snapshot,
 		)
+		self._persist_turn(input, attachment_data, run.name)
+		run_input = self._build_prompt_messages()
 
 		if stream:
 			return stream_with_persistence(lambda: self._runtime.run(run_input, stream=True), run)
@@ -150,6 +143,39 @@ class AISession(Document):
 			raise
 		run.apply_result(result)
 		return run
+
+	def _load_attachments(self, attachments: list[str] | None) -> list[dict[str, Any]]:
+		"""Validate and extract each attached file (errors surface before the run is created)."""
+		from flow.ai.doctype.ai_session_attachment.ai_session_attachment import resolve_attachment
+
+		seen: set[str] = set()
+		resolved: list[dict[str, Any]] = []
+		for file in attachments or []:
+			if file in seen:
+				continue
+			seen.add(file)
+			resolved.append(resolve_attachment(file))
+		return resolved
+
+	def _persist_turn(self, input: str, attachment_data: list[dict[str, Any]], run: str) -> None:
+		"""Persist this turn's user message (and the system message on the first turn) plus its
+		attachment rows before the run executes. Stored ahead of the run so they fall in the
+		transcript prefix the run's own message-append skips — the run persists only its output."""
+		if not self.messages and self._runtime.instructions:
+			self.append("messages", {"role": "system", "content": self._runtime.instructions, "run": run})
+		self.append("messages", {"role": "user", "content": input, "run": run})
+		for data in attachment_data:
+			self.append(
+				"attachments",
+				{
+					"file": data["file"],
+					"file_name": data["file_name"],
+					"file_size": data["file_size"],
+					"extracted_text": data["extracted_text"],
+					"run": run,
+				},
+			)
+		self.save(ignore_permissions=True)
 
 	def resume(self, answers: dict[str, Any], *, stream: bool = False) -> AIRun | Generator[Event]:
 		"""Resume this session's paused run with the user's answers."""
@@ -166,7 +192,7 @@ class AISession(Document):
 		run = frappe.get_doc("AI Run", run_name)
 
 		self.reload()
-		messages = self.transcript()
+		messages = self._build_prompt_messages()
 		if not messages:
 			frappe.throw(_("This session has no transcript to resume from."))
 
@@ -181,12 +207,25 @@ class AISession(Document):
 		run.apply_result(result)
 		return run
 
-	def _build_input(self, new_input: str) -> str | list[dict[str, Any]]:
-		transcript = self.transcript()
-		if not transcript:
-			return new_input
-		transcript.append({"role": "user", "content": new_input})
-		return transcript
+	def _build_prompt_messages(self) -> list[dict[str, Any]]:
+		"""Transcript as sent to the model: every user turn's content is augmented with the
+		text of the files attached on that turn, so the file stays in context for the whole
+		conversation (matching ChatGPT/Claude/Gemini). The augmentation is ephemeral — stored
+		messages stay clean (the file text lives only in the attachments child table)."""
+		by_run = self._group_attachments_by_run()
+		messages: list[dict[str, Any]] = []
+		for row in self.messages:
+			message = _row_to_message(row)
+			if row.role == "user" and row.run in by_run:
+				message["content"] = _inject_file_text(message["content"], by_run[row.run])
+			messages.append(message)
+		return messages
+
+	def _group_attachments_by_run(self) -> dict[str, list[Any]]:
+		grouped: dict[str, list[Any]] = {}
+		for attachment in self.attachments:
+			grouped.setdefault(attachment.run, []).append(attachment)
+		return grouped
 
 	def _assert_not_blocked(self) -> None:
 		blocking = frappe.db.get_value(
@@ -215,6 +254,27 @@ class AISession(Document):
 			_("This session already has a run in progress."),
 			title=_("Run In Progress"),
 		)
+
+
+def _row_to_message(row) -> dict[str, Any]:
+	"""Convert a stored transcript row to an OpenAI-format message dict."""
+	if row.role == "tool":
+		return {"role": "tool", "tool_call_id": row.tool_call_id, "content": row.content or ""}
+	message: dict[str, Any] = {"role": row.role, "content": row.content}
+	if row.tool_calls:
+		message["tool_calls"] = json.loads(row.tool_calls)
+	return message
+
+
+def _inject_file_text(content: str | None, attachments: list[Any]) -> str:
+	"""Append attached-file text to a user message, clearly delimited as data for the model."""
+	blocks = [
+		f"--- File: {a.file_name} ---\n{a.extracted_text}\n--- End of file: {a.file_name} ---"
+		for a in attachments
+	]
+	files = "\n\n".join(blocks)
+	body = f"{_('The user attached the following file(s):')}\n\n{files}"
+	return f"{content}\n\n{body}" if content else body
 
 
 def derive_title(text: str) -> str:

--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -55,6 +55,9 @@ class AISession(Document):
 		self._validate_agent_unchanged()
 		self._validate_model_enabled()
 
+	def on_trash(self):
+		_purge_attachment_chunks(self.name)
+
 	def _validate_model_enabled(self):
 		if not self.model:
 			return
@@ -84,7 +87,9 @@ class AISession(Document):
 		for batch in frappe.utils.create_batch(sessions, 100):
 			frappe.db.delete("AI Run", {"session": ["in", batch]})
 			frappe.db.delete("AI Session Message", {"parent": ["in", batch]})
+			frappe.db.delete("AI Session Attachment", {"parent": ["in", batch]})
 			frappe.db.delete("AI Session", {"name": ["in", batch]})
+			_purge_attachment_chunks(batch)
 
 	def transcript(self) -> list[dict[str, Any]]:
 		"""Return the conversation history in OpenAI message format."""
@@ -352,6 +357,17 @@ class AISession(Document):
 			_("This session already has a run in progress."),
 			title=_("Run In Progress"),
 		)
+
+
+def _purge_attachment_chunks(session: str | list[str]) -> None:
+	"""Best-effort removal of a session's (or batch's) retrieval chunks. The chunk index is
+	disposable, so a failure here must never block deleting the session."""
+	from flow.knowledge import attachment_store
+
+	try:
+		attachment_store.delete(session=session)
+	except Exception:
+		frappe.log_error(title="Chat attachment cleanup failed")
 
 
 def _embeddings_configured() -> bool:

--- a/flow/ai/doctype/ai_session/test_ai_session.py
+++ b/flow/ai/doctype/ai_session/test_ai_session.py
@@ -1,10 +1,26 @@
 # Copyright (c) 2026, Frappe Technologies and Contributors
 # See license.txt
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from flow.ai.doctype.ai_session.ai_session import AISession, derive_title
+from flow.ai.doctype.ai_session.ai_session import (
+	CHARS_PER_TOKEN,
+	DEFAULT_CONTEXT_WINDOW,
+	RESERVED_OUTPUT_TOKENS,
+	RETRIEVAL_FRACTION,
+	AISession,
+	_clamp,
+	_embeddings_configured,
+	_inject_inline_files,
+	_inject_retrieved_chunks,
+	_note_retrieval_files,
+	_route_attachment,
+	derive_title,
+)
 
 
 class TestAISession(IntegrationTestCase):
@@ -112,3 +128,241 @@ class TestDeriveTitle(IntegrationTestCase):
 	def test_empty_input_returns_empty_string(self):
 		self.assertEqual(derive_title(""), "")
 		self.assertEqual(derive_title(None), "")
+
+
+def _att(file_name="f.txt", extracted_text="", mode="Inline", run=None):
+	return SimpleNamespace(file_name=file_name, extracted_text=extracted_text, mode=mode, run=run)
+
+
+class TestAttachmentRouting(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_small_file_is_inline(self):
+		self.assertEqual(_route_attachment("x" * 100, threshold=1000, embeddings_on=True), "Inline")
+
+	def test_at_threshold_is_inline(self):
+		self.assertEqual(_route_attachment("x" * 1000, threshold=1000, embeddings_on=True), "Inline")
+
+	def test_oversized_with_embeddings_is_retrieval(self):
+		self.assertEqual(_route_attachment("x" * 2000, threshold=1000, embeddings_on=True), "Retrieval")
+
+	def test_oversized_without_embeddings_stays_inline(self):
+		self.assertEqual(_route_attachment("x" * 2000, threshold=1000, embeddings_on=False), "Inline")
+
+	def test_none_text_is_inline(self):
+		self.assertEqual(_route_attachment(None, threshold=1000, embeddings_on=True), "Inline")
+
+	def test_embeddings_configured_reflects_settings(self):
+		frappe.db.set_single_value("AI Knowledge Settings", "embedding_model", "")
+		frappe.clear_document_cache("AI Knowledge Settings", "AI Knowledge Settings")
+		self.assertFalse(_embeddings_configured())
+
+
+class TestAttachmentInjection(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_inline_injects_full_text_and_decrements_budget(self):
+		content, budget = _inject_inline_files("hi", [_att(extracted_text="FULLBODY")], 1000)
+		self.assertIn("FULLBODY", content)
+		self.assertIn("f.txt", content)
+		self.assertEqual(budget, 1000 - len("FULLBODY"))
+
+	def test_inline_truncates_over_budget_with_marker(self):
+		content, budget = _inject_inline_files("", [_att(extracted_text="X" * 100)], 10)
+		self.assertIn("truncated", content.lower())
+		self.assertEqual(budget, 0)
+
+	def test_note_names_files(self):
+		note = _note_retrieval_files("q", [_att(file_name="report.pdf")])
+		self.assertIn("report.pdf", note)
+
+	def test_chunks_injected_within_budget(self):
+		content, _ = _inject_retrieved_chunks("q", [{"content": "ALPHA"}, {"content": "BETA"}], 1000)
+		self.assertIn("ALPHA", content)
+		self.assertIn("BETA", content)
+
+	def test_chunks_stop_at_budget(self):
+		content, budget = _inject_retrieved_chunks("q", [{"content": "X" * 100}], 5)
+		self.assertEqual(budget, 0)
+		self.assertIn("Relevant", content)
+
+	def test_no_chunks_leaves_content_unchanged(self):
+		content, budget = _inject_retrieved_chunks("q", [], 1000)
+		self.assertEqual(content, "q")
+		self.assertEqual(budget, 1000)
+
+	def test_clamp_within_over_and_zero(self):
+		self.assertEqual(_clamp("hello", 10), ("hello", False))
+		self.assertEqual(_clamp("hello", 3), ("hel", True))
+		self.assertEqual(_clamp("hello", 0), ("", True))
+
+
+class TestAttachmentBudget(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _session(self, snapshot=None):
+		s = frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True)
+		s._snapshot = snapshot if snapshot is not None else {"model": None}
+		return s
+
+	def test_context_window_defaults_when_model_unknown(self):
+		self.assertEqual(self._session()._context_window(), DEFAULT_CONTEXT_WINDOW)
+
+	def test_context_window_reads_model_field(self):
+		model = frappe.get_doc(
+			{
+				"doctype": "AI Model",
+				"title": "CW Model",
+				"model_id": "openai/gpt-4o-mini",
+				"context_window": 9000,
+			}
+		).insert()
+		self.assertEqual(self._session({"model": model.name})._context_window(), 9000)
+
+	def test_inline_threshold_is_fraction_of_window(self):
+		expected = int(DEFAULT_CONTEXT_WINDOW * CHARS_PER_TOKEN * RETRIEVAL_FRACTION)
+		self.assertEqual(self._session()._attachment_inline_threshold(), expected)
+
+	def test_budget_shrinks_with_dialogue(self):
+		s = self._session()
+		base = DEFAULT_CONTEXT_WINDOW * CHARS_PER_TOKEN - RESERVED_OUTPUT_TOKENS * CHARS_PER_TOKEN
+		self.assertEqual(s._file_injection_budget(), base)  # no messages yet
+		s.append("messages", {"role": "user", "content": "x" * 500, "run": None})
+		s.save(ignore_permissions=True)
+		s._snapshot = {"model": None}
+		self.assertEqual(s._file_injection_budget(), base - 500)
+
+	def test_budget_floors_at_zero(self):
+		model = frappe.get_doc(
+			{"doctype": "AI Model", "title": "Tiny", "model_id": "openai/gpt-4o-mini", "context_window": 1}
+		).insert()
+		s = self._session({"model": model.name})
+		s.append("messages", {"role": "user", "content": "x" * 10000, "run": None})
+		s.save(ignore_permissions=True)
+		s._snapshot = {"model": model.name}
+		self.assertEqual(s._file_injection_budget(), 0)
+
+
+class TestBuildPromptMessages(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _file(self):
+		return frappe.get_doc(
+			{"doctype": "File", "file_name": "f.txt", "content": "x", "is_private": 1}
+		).insert(ignore_permissions=True)
+
+	def test_inline_full_text_injected_on_its_turn(self):
+		s = frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True)
+		s._snapshot = {"model": None}
+		f = self._file()
+		s.append("messages", {"role": "user", "content": "summarize", "run": None})
+		s.append(
+			"attachments",
+			{
+				"file": f.name,
+				"file_name": "f.txt",
+				"file_size": 3,
+				"extracted_text": "INLINEBODY",
+				"mode": "Inline",
+			},
+		)
+		s.save(ignore_permissions=True)
+		content = next(m for m in s._build_prompt_messages() if m["role"] == "user")["content"]
+		self.assertIn("INLINEBODY", content)
+
+	def test_retrieval_injects_chunks_not_full_text(self):
+		s = frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True)
+		s._snapshot = {"model": None}
+		f = self._file()
+		big = "SECRETFULLTEXT " * 50
+		s.append("messages", {"role": "user", "content": "what does it say", "run": None})
+		s.append(
+			"attachments",
+			{
+				"file": f.name,
+				"file_name": "big.txt",
+				"file_size": len(big),
+				"extracted_text": big,
+				"mode": "Retrieval",
+			},
+		)
+		s.save(ignore_permissions=True)
+		with patch(
+			"flow.knowledge.retriever.retrieve_attachments", return_value=[{"content": "CHUNKED_EXCERPT"}]
+		):
+			content = next(m for m in s._build_prompt_messages() if m["role"] == "user")["content"]
+		self.assertIn("big.txt", content)  # note marks the attachment
+		self.assertIn("CHUNKED_EXCERPT", content)  # excerpt injected
+		self.assertNotIn("SECRETFULLTEXT", content)  # full text NOT injected
+
+	def test_no_attachments_leaves_message_clean(self):
+		s = frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True)
+		s._snapshot = {"model": None}
+		s.append("messages", {"role": "user", "content": "hello", "run": None})
+		s.save(ignore_permissions=True)
+		content = next(m for m in s._build_prompt_messages() if m["role"] == "user")["content"]
+		self.assertEqual(content, "hello")
+
+
+class TestIndexRetrievalAttachments(IntegrationTestCase):
+	def setUp(self):
+		frappe.db.set_single_value("AI Knowledge Settings", "chunk_size", 200)
+		frappe.db.set_single_value("AI Knowledge Settings", "chunk_overlap", 20)
+		frappe.db.set_single_value("AI Knowledge Settings", "embedding_dimension", 4)
+		frappe.clear_document_cache("AI Knowledge Settings", "AI Knowledge Settings")
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _session_with_retrieval(self, text):
+		f = frappe.get_doc({"doctype": "File", "file_name": "f.txt", "content": "x", "is_private": 1}).insert(
+			ignore_permissions=True
+		)
+		s = frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True)
+		s.append(
+			"attachments",
+			{
+				"file": f.name,
+				"file_name": "f.txt",
+				"file_size": len(text),
+				"extracted_text": text,
+				"mode": "Retrieval",
+				"run": None,
+			},
+		)
+		s.save(ignore_permissions=True)
+		return s
+
+	def test_indexes_chunks_and_keeps_retrieval_mode(self):
+		s = self._session_with_retrieval("Revenue grew twelve percent this quarter. " * 20)
+		with (
+			patch(
+				"flow.knowledge.embedder.embed_texts",
+				side_effect=lambda chunks: [[1.0, 0.0, 0.0, 0.0]] * len(chunks),
+			),
+			patch("flow.knowledge.attachment_store.ensure_table"),
+			patch("flow.knowledge.attachment_store.add") as add,
+		):
+			s._index_retrieval_attachments(None)
+		add.assert_called_once()
+		s.reload()
+		self.assertEqual(s.attachments[0].mode, "Retrieval")
+
+	def test_empty_text_demotes_to_inline(self):
+		s = self._session_with_retrieval("   ")
+		with patch("flow.knowledge.embedder.embed_texts") as embed:
+			s._index_retrieval_attachments(None)
+		embed.assert_not_called()  # nothing to chunk -> no embedding
+		s.reload()
+		self.assertEqual(s.attachments[0].mode, "Inline")
+
+	def test_embedding_failure_demotes_to_inline(self):
+		s = self._session_with_retrieval("Some content worth chunking. " * 20)
+		with patch("flow.knowledge.embedder.embed_texts", side_effect=RuntimeError("provider down")):
+			s._index_retrieval_attachments(None)
+		s.reload()
+		self.assertEqual(s.attachments[0].mode, "Inline")

--- a/flow/ai/doctype/ai_session/test_ai_session.py
+++ b/flow/ai/doctype/ai_session/test_ai_session.py
@@ -83,8 +83,12 @@ class TestClearOldLogs(IntegrationTestCase):
 		frappe.db.rollback()
 
 	def _session_with_run(self, *, age_days: int) -> str:
+		f = frappe.get_doc({"doctype": "File", "file_name": "f.txt", "content": "x", "is_private": 1}).insert(
+			ignore_permissions=True
+		)
 		session = frappe.get_doc({"doctype": "AI Session", "title": "chat"})
 		session.append("messages", {"role": "user", "content": "hi"})
+		session.append("attachments", {"file": f.name, "file_name": "f.txt", "file_size": 1})
 		session.insert(ignore_permissions=True)
 		run = frappe.get_doc(
 			{"doctype": "AI Run", "session": session.name, "source": "Manual", "status": "Completed"}
@@ -101,6 +105,7 @@ class TestClearOldLogs(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("AI Session", old_session))
 		self.assertFalse(frappe.db.exists("AI Run", old_run))
 		self.assertEqual(frappe.db.count("AI Session Message", {"parent": old_session}), 0)
+		self.assertEqual(frappe.db.count("AI Session Attachment", {"parent": old_session}), 0)
 
 	def test_recent_session_is_kept(self):
 		recent_session, recent_run = self._session_with_run(age_days=1)
@@ -366,3 +371,29 @@ class TestIndexRetrievalAttachments(IntegrationTestCase):
 			s._index_retrieval_attachments(None)
 		s.reload()
 		self.assertEqual(s.attachments[0].mode, "Inline")
+
+
+class TestAttachmentCleanup(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_on_trash_purges_session_chunks(self):
+		s = frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True)
+		with patch("flow.knowledge.attachment_store.delete") as delete:
+			frappe.delete_doc("AI Session", s.name, ignore_permissions=True)
+		delete.assert_called_once_with(session=s.name)
+
+	def test_cleanup_failure_does_not_block_delete(self):
+		s = frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True)
+		with patch("flow.knowledge.attachment_store.delete", side_effect=RuntimeError("store down")):
+			frappe.delete_doc("AI Session", s.name, ignore_permissions=True)
+		self.assertFalse(frappe.db.exists("AI Session", s.name))
+
+	def test_clear_old_logs_purges_chunks_for_batch(self):
+		s = frappe.get_doc({"doctype": "AI Session", "title": "old"}).insert(ignore_permissions=True)
+		old = frappe.utils.add_days(frappe.utils.now(), -100)
+		frappe.db.set_value("AI Session", s.name, "modified", old, update_modified=False)
+		with patch("flow.knowledge.attachment_store.delete") as delete:
+			AISession.clear_old_logs(days=30)
+		batch = delete.call_args.kwargs["session"]
+		self.assertIn(s.name, batch)

--- a/flow/ai/doctype/ai_session_attachment/ai_session_attachment.json
+++ b/flow/ai/doctype/ai_session_attachment/ai_session_attachment.json
@@ -1,0 +1,68 @@
+{
+ "actions": [],
+ "creation": "2026-06-24 00:00:00",
+ "doctype": "DocType",
+ "editable_grid": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "file",
+  "file_name",
+  "file_size",
+  "run",
+  "extracted_text"
+ ],
+ "fields": [
+  {
+   "fieldname": "file",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "File",
+   "options": "File",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "file_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "File Name",
+   "read_only": 1
+  },
+  {
+   "description": "Size in bytes.",
+   "fieldname": "file_size",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "File Size",
+   "read_only": 1
+  },
+  {
+   "description": "The run (turn) this file was sent with.",
+   "fieldname": "run",
+   "fieldtype": "Link",
+   "label": "Run",
+   "options": "AI Run",
+   "read_only": 1
+  },
+  {
+   "fieldname": "extracted_text",
+   "fieldtype": "Long Text",
+   "label": "Extracted Text",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-06-24 00:00:00",
+ "modified_by": "Administrator",
+ "module": "AI",
+ "name": "AI Session Attachment",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "idx",
+ "sort_order": "ASC",
+ "states": [],
+ "track_changes": 0
+}

--- a/flow/ai/doctype/ai_session_attachment/ai_session_attachment.json
+++ b/flow/ai/doctype/ai_session_attachment/ai_session_attachment.json
@@ -9,6 +9,7 @@
   "file_name",
   "file_size",
   "run",
+  "mode",
   "extracted_text"
  ],
  "fields": [
@@ -42,6 +43,15 @@
    "fieldtype": "Link",
    "label": "Run",
    "options": "AI Run",
+   "read_only": 1
+  },
+  {
+   "default": "Inline",
+   "description": "Inline: full text injected every turn. Retrieval: chunked and embedded, top matches injected per turn (for oversized files).",
+   "fieldname": "mode",
+   "fieldtype": "Select",
+   "label": "Mode",
+   "options": "Inline\nRetrieval",
    "read_only": 1
   },
   {

--- a/flow/ai/doctype/ai_session_attachment/ai_session_attachment.py
+++ b/flow/ai/doctype/ai_session_attachment/ai_session_attachment.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+from flow.knowledge.extract import FILE_EXTENSIONS, extract_file
+
+# Extracted text is staged here between upload and send, so it survives without a
+# session (the child row can only be written once the session exists, at send time).
+CACHE_PREFIX = "chat_attachment"
+CACHE_TTL = 3600
+
+
+class AISessionAttachment(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		extracted_text: DF.LongText | None
+		file: DF.Link
+		file_name: DF.Data | None
+		file_size: DF.Int
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		run: DF.Link | None
+	# end: auto-generated types
+
+	pass
+
+
+def extract_attachment(file: str) -> dict[str, Any]:
+	"""Validate and extract text from an uploaded File. Raises (so errors surface at
+	upload time) if the caller doesn't own the file, the type is unsupported, or no
+	text can be read. Returns the fields needed to write an attachment row."""
+	file_doc = frappe.get_doc("File", file)
+	if not frappe.has_permission("File", "read", doc=file_doc):
+		frappe.throw(_("Not permitted to use this file."), frappe.PermissionError)
+
+	extension = os.path.splitext(file_doc.file_name or "")[1].lower().lstrip(".")
+	if extension not in FILE_EXTENSIONS:
+		frappe.throw(_("Unsupported file type: .{0}").format(extension or "?"), title=_("Unsupported File"))
+
+	text = extract_file(file_doc)
+	if not text:
+		frappe.throw(_("No readable text found in this file."), title=_("Empty File"))
+
+	return {
+		"file": file_doc.name,
+		"file_name": file_doc.file_name,
+		"file_size": file_doc.file_size,
+		"extracted_text": text,
+	}
+
+
+def _cache_key(file: str) -> str:
+	return f"{CACHE_PREFIX}:{frappe.session.user}:{file}"
+
+
+def stage_attachment(file: str) -> dict[str, Any]:
+	"""Extract at upload time and cache the text, so send can write the child row
+	without re-parsing. Returns lightweight metadata for the composer chip."""
+	data = extract_attachment(file)
+	frappe.cache.set_value(_cache_key(file), data["extracted_text"], expires_in_sec=CACHE_TTL)
+	return {"file": data["file"], "file_name": data["file_name"], "file_size": data["file_size"]}
+
+
+def staged_text(file: str) -> str | None:
+	"""Read text staged at upload time. None if it has expired and must be re-extracted."""
+	return frappe.cache.get_value(_cache_key(file))

--- a/flow/ai/doctype/ai_session_attachment/ai_session_attachment.py
+++ b/flow/ai/doctype/ai_session_attachment/ai_session_attachment.py
@@ -69,13 +69,19 @@ def _cache_key(file: str) -> str:
 
 
 def stage_attachment(file: str) -> dict[str, Any]:
-	"""Extract at upload time and cache the text, so send can write the child row
+	"""Extract at upload time and cache the result, so send can write the child row
 	without re-parsing. Returns lightweight metadata for the composer chip."""
 	data = extract_attachment(file)
-	frappe.cache.set_value(_cache_key(file), data["extracted_text"], expires_in_sec=CACHE_TTL)
+	frappe.cache.set_value(_cache_key(file), data, expires_in_sec=CACHE_TTL)
 	return {"file": data["file"], "file_name": data["file_name"], "file_size": data["file_size"]}
 
 
-def staged_text(file: str) -> str | None:
-	"""Read text staged at upload time. None if it has expired and must be re-extracted."""
+def staged_attachment(file: str) -> dict[str, Any] | None:
+	"""Read the extraction staged at upload time. None if it has expired."""
 	return frappe.cache.get_value(_cache_key(file))
+
+
+def resolve_attachment(file: str) -> dict[str, Any]:
+	"""Materialize an attachment at send time. Prefers the upload-time staged extraction;
+	on a cache miss it re-extracts, which also re-checks the caller's read permission."""
+	return staged_attachment(file) or extract_attachment(file)

--- a/flow/ai/doctype/ai_session_attachment/ai_session_attachment.py
+++ b/flow/ai/doctype/ai_session_attachment/ai_session_attachment.py
@@ -31,6 +31,7 @@ class AISessionAttachment(Document):
 		file: DF.Link
 		file_name: DF.Data | None
 		file_size: DF.Int
+		mode: DF.Literal["Inline", "Retrieval"]
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/flow/ai/doctype/ai_session_attachment/test_ai_session_attachment.py
+++ b/flow/ai/doctype/ai_session_attachment/test_ai_session_attachment.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, Frappe Technologies and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from flow.ai.doctype.ai_session_attachment.ai_session_attachment import (
+	extract_attachment,
+	stage_attachment,
+	staged_text,
+)
+
+
+def _file(file_name="note.txt", content="attachment body", **kwargs):
+	return frappe.get_doc(
+		{"doctype": "File", "file_name": file_name, "content": content, "is_private": 1, **kwargs}
+	).insert(ignore_permissions=True)
+
+
+def _ensure_user(email):
+	if frappe.db.exists("User", email):
+		return email
+	frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": email,
+			"first_name": email.split("@")[0],
+			"send_welcome_email": 0,
+			"enabled": 1,
+		}
+	).insert(ignore_permissions=True)
+	return email
+
+
+class TestExtractAttachment(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def test_extracts_text_and_metadata(self):
+		file_doc = _file(content="attachment body")
+		data = extract_attachment(file_doc.name)
+		self.assertEqual(data["file"], file_doc.name)
+		self.assertEqual(data["file_name"], "note.txt")
+		self.assertEqual(data["file_size"], file_doc.file_size)
+		self.assertEqual(data["extracted_text"], "attachment body")
+
+	def test_rejects_unsupported_extension(self):
+		file_doc = _file(file_name="data.bin", content="x")
+		with self.assertRaisesRegex(frappe.ValidationError, "Unsupported file type"):
+			extract_attachment(file_doc.name)
+
+	def test_rejects_empty_text(self):
+		file_doc = _file(file_name="blank.txt", content="   ")
+		with self.assertRaisesRegex(frappe.ValidationError, "No readable text"):
+			extract_attachment(file_doc.name)
+
+	def test_rejects_file_not_readable_by_user(self):
+		# Owned by Administrator and private: a regular user must not be able to attach it.
+		file_doc = _file(content="secret body")
+		frappe.set_user(_ensure_user("attach-other@example.com"))
+		with self.assertRaises(frappe.PermissionError):
+			extract_attachment(file_doc.name)
+
+	def test_owner_can_attach_own_file(self):
+		frappe.set_user(_ensure_user("attach-owner@example.com"))
+		file_doc = _file(file_name="mine.txt", content="my own notes")
+		data = extract_attachment(file_doc.name)
+		self.assertEqual(data["extracted_text"], "my own notes")
+
+
+class TestStageAttachment(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def test_stage_caches_text_and_returns_chip_metadata(self):
+		file_doc = _file(content="staged body")
+		chip = stage_attachment(file_doc.name)
+		self.assertEqual(set(chip), {"file", "file_name", "file_size"})
+		self.assertEqual(chip["file"], file_doc.name)
+		self.assertEqual(staged_text(file_doc.name), "staged body")
+
+	def test_staged_text_is_user_scoped(self):
+		file_doc = _file(content="staged body")
+		stage_attachment(file_doc.name)  # cached under Administrator
+		frappe.set_user(_ensure_user("attach-scope@example.com"))
+		self.assertIsNone(staged_text(file_doc.name))
+
+	def test_staged_text_missing_returns_none(self):
+		self.assertIsNone(staged_text("no-such-file"))

--- a/flow/ai/doctype/ai_session_attachment/test_ai_session_attachment.py
+++ b/flow/ai/doctype/ai_session_attachment/test_ai_session_attachment.py
@@ -6,8 +6,9 @@ from frappe.tests import IntegrationTestCase
 
 from flow.ai.doctype.ai_session_attachment.ai_session_attachment import (
 	extract_attachment,
+	resolve_attachment,
 	stage_attachment,
-	staged_text,
+	staged_attachment,
 )
 
 
@@ -74,18 +75,33 @@ class TestStageAttachment(IntegrationTestCase):
 		frappe.set_user("Administrator")
 		frappe.db.rollback()
 
-	def test_stage_caches_text_and_returns_chip_metadata(self):
+	def test_stage_caches_extraction_and_returns_chip_metadata(self):
 		file_doc = _file(content="staged body")
 		chip = stage_attachment(file_doc.name)
 		self.assertEqual(set(chip), {"file", "file_name", "file_size"})
 		self.assertEqual(chip["file"], file_doc.name)
-		self.assertEqual(staged_text(file_doc.name), "staged body")
+		self.assertEqual(staged_attachment(file_doc.name)["extracted_text"], "staged body")
 
-	def test_staged_text_is_user_scoped(self):
+	def test_staged_attachment_is_user_scoped(self):
 		file_doc = _file(content="staged body")
 		stage_attachment(file_doc.name)  # cached under Administrator
 		frappe.set_user(_ensure_user("attach-scope@example.com"))
-		self.assertIsNone(staged_text(file_doc.name))
+		self.assertIsNone(staged_attachment(file_doc.name))
 
-	def test_staged_text_missing_returns_none(self):
-		self.assertIsNone(staged_text("no-such-file"))
+	def test_staged_attachment_missing_returns_none(self):
+		self.assertIsNone(staged_attachment("no-such-file"))
+
+	def test_resolve_uses_cache_then_falls_back_to_extraction(self):
+		file_doc = _file(content="resolved body")
+		stage_attachment(file_doc.name)
+		self.assertEqual(resolve_attachment(file_doc.name)["extracted_text"], "resolved body")
+
+		frappe.cache.delete_value(f"chat_attachment:{frappe.session.user}:{file_doc.name}")
+		# Cache miss re-extracts (and re-checks permission).
+		self.assertEqual(resolve_attachment(file_doc.name)["extracted_text"], "resolved body")
+
+	def test_resolve_on_cache_miss_rejects_unreadable_file(self):
+		file_doc = _file(content="secret body")  # owned by Administrator, private
+		frappe.set_user(_ensure_user("attach-miss@example.com"))
+		with self.assertRaises(frappe.PermissionError):
+			resolve_attachment(file_doc.name)

--- a/flow/api/__init__.py
+++ b/flow/api/__init__.py
@@ -1,4 +1,4 @@
 # Re-exported so whitelisted endpoints stay reachable at flow.api.<name>.
-from flow.api.api import attach_file, resume_run, start_run
+from flow.api.api import attach_file, recover_session, resume_run, start_run
 
-__all__ = ["attach_file", "resume_run", "start_run"]
+__all__ = ["attach_file", "recover_session", "resume_run", "start_run"]

--- a/flow/api/__init__.py
+++ b/flow/api/__init__.py
@@ -1,4 +1,4 @@
 # Re-exported so whitelisted endpoints stay reachable at flow.api.<name>.
-from flow.api.api import resume_run, start_run
+from flow.api.api import attach_file, resume_run, start_run
 
-__all__ = ["resume_run", "start_run"]
+__all__ = ["attach_file", "resume_run", "start_run"]

--- a/flow/api/api.py
+++ b/flow/api/api.py
@@ -63,6 +63,29 @@ def resume_run(
 
 
 @frappe.whitelist()
+def recover_session(session: str) -> dict[str, int]:
+	"""Fail any Running run on session (re)load. The client that owned the stream is
+	gone, so the run is abandoned; clearing it here unblocks the next turn instead of
+	waiting for the stale-run timeout on the next send."""
+	if not isinstance(session, str) or not session.strip():
+		frappe.throw(_("Session is required."), title=_("Invalid Session"))
+
+	from flow.lib.session import _assert_session_owner
+
+	doc = frappe.get_doc("AI Session", session.strip())
+	_assert_session_owner(doc)
+
+	abandoned = frappe.get_all("AI Run", filters={"session": doc.name, "status": "Running"}, pluck="name")
+	for name in abandoned:
+		frappe.db.set_value(
+			"AI Run",
+			name,
+			{"status": "Failed", "error": "Run abandoned: stream ended without completing."},
+		)
+	return {"recovered": len(abandoned)}
+
+
+@frappe.whitelist()
 def attach_file(file: str) -> dict[str, Any]:
 	"""Validate and extract an uploaded File for use as a chat attachment. Errors
 	(unsupported type, unreadable, not owned) surface here, at upload time. The

--- a/flow/api/api.py
+++ b/flow/api/api.py
@@ -23,17 +23,20 @@ def start_run(
 	agent: str | None = None,
 	session: str | None = None,
 	model: str | None = None,
+	attachments: list[str] | str | None = None,
 	stream: bool | str = False,
 ) -> dict[str, Any] | Response:
-	"""Start a new turn. Creates a session if none is given. With `stream=True`, returns SSE."""
+	"""Start a new turn. Creates a session if none is given. `attachments` are uploaded File
+	names whose text is injected into this turn. With `stream=True`, returns SSE."""
 	if not isinstance(input, str) or not input.strip():
 		frappe.throw(_("Input is required."), title=_("Invalid Input"))
 
 	from flow.lib.session import load_session, new_session
 
 	stream = _is_truthy(stream)
+	files = _parse_attachments(attachments)
 	convo = load_session(session, agent=agent, model=model) if session else new_session(agent, model=model)
-	out = convo.chat(input, stream=stream)
+	out = convo.chat(input, attachments=files, stream=stream)
 	return _sse_response(out) if stream else _summarize(out)
 
 
@@ -130,6 +133,25 @@ def _is_truthy(value: Any) -> bool:
 	if isinstance(value, str):
 		return value.strip().lower() in {"1", "true", "yes", "on"}
 	return bool(value)
+
+
+def _parse_attachments(value: Any) -> list[str]:
+	"""Normalize the attachments argument (a list, a JSON-array string, or empty) to file names."""
+	if not value:
+		return []
+	if isinstance(value, str):
+		try:
+			value = json.loads(value)
+		except (TypeError, ValueError):
+			frappe.throw(_("Attachments must be a JSON array of file ids."), title=_("Invalid Attachments"))
+	if not isinstance(value, list):
+		frappe.throw(_("Attachments must be a list of file ids."), title=_("Invalid Attachments"))
+	files: list[str] = []
+	for file in value:
+		if not isinstance(file, str) or not file.strip():
+			frappe.throw(_("Each attachment must be a file id."), title=_("Invalid Attachments"))
+		files.append(file.strip())
+	return files
 
 
 def _parse_answers(answers: Any) -> dict[str, Any]:

--- a/flow/api/api.py
+++ b/flow/api/api.py
@@ -59,6 +59,19 @@ def resume_run(
 	return _sse_response(out) if stream else _summarize(out)
 
 
+@frappe.whitelist()
+def attach_file(file: str) -> dict[str, Any]:
+	"""Validate and extract an uploaded File for use as a chat attachment. Errors
+	(unsupported type, unreadable, not owned) surface here, at upload time. The
+	extracted text is staged in cache; the attachment row is written on send."""
+	if not isinstance(file, str) or not file.strip():
+		frappe.throw(_("File is required."), title=_("Invalid Attachment"))
+
+	from flow.ai.doctype.ai_session_attachment.ai_session_attachment import stage_attachment
+
+	return stage_attachment(file.strip())
+
+
 def _sse_response(events: Iterable[Event]) -> Response:
 	"""Wrap an event iterable as an SSE HTTP response."""
 

--- a/flow/knowledge/attachment_store.py
+++ b/flow/knowledge/attachment_store.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import pyarrow as pa
 
-from flow.knowledge.store import _connect, _quote, _vector_dim
+from flow.knowledge.store import _connect, _ensure_fts_index, _quote, _vector_dim
 
 TABLE_NAME = "chat_attachment_chunks"
 MAX_SEARCH_LIMIT = 50
@@ -65,14 +65,19 @@ def add(session: str, attachment: str, chunks: list[str], vectors: list[list[flo
 		}
 		for content, vector in zip(chunks, vectors, strict=True)
 	]
-	_open_table().add(rows)
+	table = _open_table()
+	table.add(rows)
+	_ensure_fts_index(table)
 
 
-def search(vector: list[float], *, session: str, limit: int = 8) -> list[dict[str, Any]]:
-	"""Nearest-neighbour chunks within one session, most relevant first.
+def search(
+	vector: list[float], *, session: str, text: str | None = None, limit: int = 8
+) -> list[dict[str, Any]]:
+	"""Best-matching chunks within one session, most relevant first.
 
-	Returns [{content, score}] with higher score = better match. Scoping to
-	`session` is mandatory — there is no unscoped search.
+	With `text`, runs hybrid search (vector + full-text, rank-fused); otherwise
+	vector-only. Returns [{content, score}] with higher score = better match. Scoping
+	to `session` is mandatory — there is no unscoped search.
 	"""
 	if not session:
 		raise ValueError("search requires a session scope")
@@ -84,13 +89,17 @@ def search(vector: list[float], *, session: str, limit: int = 8) -> list[dict[st
 		return []
 
 	limit = max(1, min(int(limit), MAX_SEARCH_LIMIT))
-	query = (
-		table.search([float(v) for v in vector], vector_column_name="vector")
-		.distance_type("cosine")
-		.where(f"session = {_quote(session)}", prefilter=True)
-		.limit(limit)
-	)
-	return [{"content": row["content"], "score": 1.0 - row["_distance"]} for row in query.to_list()]
+	vector = [float(v) for v in vector]
+	if text:
+		_ensure_fts_index(table)
+		query = table.search(query_type="hybrid", vector_column_name="vector").vector(vector).text(text)
+	else:
+		query = table.search(vector, vector_column_name="vector")
+	query = query.distance_type("cosine").where(f"session = {_quote(session)}", prefilter=True).limit(limit)
+	return [
+		{"content": row["content"], "score": row["_relevance_score"] if text else 1.0 - row["_distance"]}
+		for row in query.to_list()
+	]
 
 
 def delete(*, session: str | None = None, attachment: str | None = None) -> None:

--- a/flow/knowledge/attachment_store.py
+++ b/flow/knowledge/attachment_store.py
@@ -102,16 +102,22 @@ def search(
 	]
 
 
-def delete(*, session: str | None = None, attachment: str | None = None) -> None:
-	"""Delete rows matching ALL given criteria. At least one is required."""
+def delete(*, session: str | list[str] | None = None, attachment: str | None = None) -> None:
+	"""Delete rows matching ALL given criteria. At least one is required.
+	`session` may be a single id or a list of ids (an empty list is a no-op)."""
 	if session is None and attachment is None:
 		raise ValueError("delete() requires session and/or attachment")
+	if isinstance(session, list) and not session:
+		return
 	if not _table_exists():
 		return
 
 	conditions = []
 	if session is not None:
-		conditions.append(f"session = {_quote(session)}")
+		if isinstance(session, str):
+			conditions.append(f"session = {_quote(session)}")
+		else:
+			conditions.append(f"session IN ({', '.join(_quote(s) for s in session)})")
 	if attachment is not None:
 		conditions.append(f"attachment = {_quote(attachment)}")
 	_open_table().delete(" AND ".join(conditions))

--- a/flow/knowledge/attachment_store.py
+++ b/flow/knowledge/attachment_store.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+"""Ephemeral, session-scoped vector store for oversized chat attachments.
+
+Separate from the curated KB store (store.py) so chat files never surface in
+agent knowledge-base search. Reads are scoped by `session`; the session-owner
+check in load_session() is the authorization boundary, enforced before any
+search runs. The `extracted_text` column is the source of truth; this index is
+disposable and rebuildable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+
+from flow.knowledge.store import _connect, _quote, _vector_dim
+
+TABLE_NAME = "chat_attachment_chunks"
+MAX_SEARCH_LIMIT = 50
+
+
+def ensure_table(dimension: int):
+	"""Open the chunks table for the given vector width, creating it if missing.
+
+	On a width mismatch (the embedding model changed) the table is dropped and
+	recreated — chat chunks are ephemeral and rebuildable, so they are not worth
+	preserving across an embedding-model change.
+	"""
+	if not isinstance(dimension, int) or dimension < 1:
+		raise ValueError(f"Invalid embedding dimension: {dimension!r}")
+
+	db = _connect()
+	if TABLE_NAME in db.list_tables().tables:
+		table = db.open_table(TABLE_NAME)
+		if _vector_dim(table) == dimension:
+			return table
+		db.drop_table(TABLE_NAME)
+
+	schema = pa.schema(
+		[
+			pa.field("session", pa.string()),
+			pa.field("attachment", pa.string()),
+			pa.field("content", pa.string()),
+			pa.field("vector", pa.list_(pa.float32(), dimension)),
+		]
+	)
+	return db.create_table(TABLE_NAME, schema=schema, exist_ok=True)
+
+
+def add(session: str, attachment: str, chunks: list[str], vectors: list[list[float]]) -> None:
+	"""Insert one attachment's chunks. The table must already exist (ensure_table)."""
+	if len(chunks) != len(vectors):
+		raise ValueError(f"chunks/vectors length mismatch: {len(chunks)} != {len(vectors)}")
+	if not chunks:
+		return
+	rows = [
+		{
+			"session": session,
+			"attachment": attachment,
+			"content": content,
+			"vector": [float(v) for v in vector],
+		}
+		for content, vector in zip(chunks, vectors, strict=True)
+	]
+	_open_table().add(rows)
+
+
+def search(vector: list[float], *, session: str, limit: int = 8) -> list[dict[str, Any]]:
+	"""Nearest-neighbour chunks within one session, most relevant first.
+
+	Returns [{content, score}] with higher score = better match. Scoping to
+	`session` is mandatory — there is no unscoped search.
+	"""
+	if not session:
+		raise ValueError("search requires a session scope")
+	if not _table_exists():
+		return []
+
+	table = _open_table()
+	if table.count_rows() == 0:
+		return []
+
+	limit = max(1, min(int(limit), MAX_SEARCH_LIMIT))
+	query = (
+		table.search([float(v) for v in vector], vector_column_name="vector")
+		.distance_type("cosine")
+		.where(f"session = {_quote(session)}", prefilter=True)
+		.limit(limit)
+	)
+	return [{"content": row["content"], "score": 1.0 - row["_distance"]} for row in query.to_list()]
+
+
+def delete(*, session: str | None = None, attachment: str | None = None) -> None:
+	"""Delete rows matching ALL given criteria. At least one is required."""
+	if session is None and attachment is None:
+		raise ValueError("delete() requires session and/or attachment")
+	if not _table_exists():
+		return
+
+	conditions = []
+	if session is not None:
+		conditions.append(f"session = {_quote(session)}")
+	if attachment is not None:
+		conditions.append(f"attachment = {_quote(attachment)}")
+	_open_table().delete(" AND ".join(conditions))
+
+
+def drop_table() -> None:
+	db = _connect()
+	if TABLE_NAME in db.list_tables().tables:
+		db.drop_table(TABLE_NAME)
+
+
+def _table_exists() -> bool:
+	return TABLE_NAME in _connect().list_tables().tables
+
+
+def _open_table():
+	return _connect().open_table(TABLE_NAME)

--- a/flow/knowledge/extract.py
+++ b/flow/knowledge/extract.py
@@ -18,6 +18,7 @@ import frappe
 from frappe import _
 
 TEXT_EXTENSIONS = {"txt", "text", "md", "markdown", "csv", "tsv", "log", "rst", "json", "yaml", "yml"}
+FILE_EXTENSIONS = {"pdf", "xlsx", "docx", "html", "htm"} | TEXT_EXTENSIONS
 
 CHILD_FIELDTYPES = {"Table", "Table MultiSelect"}
 HTML_FIELDTYPES = {"Text Editor"}
@@ -53,9 +54,14 @@ def _extract_text_source(source) -> list[ExtractedDoc]:
 
 def _extract_file_source(source) -> list[ExtractedDoc]:
 	file_doc = frappe.get_doc("File", {"file_url": source.file})
-	extension = os.path.splitext(file_doc.file_name or source.file or "")[1].lower().lstrip(".")
-	text = _extract_by_extension(file_doc.get_content(), extension)
-	return _single(text.strip())
+	return _single(extract_file(file_doc))
+
+
+def extract_file(file_doc) -> str:
+	"""Extract plain text from a File document by its extension. Reusable for any
+	caller (knowledge sources, chat attachments) that holds a File doc."""
+	extension = os.path.splitext(file_doc.file_name or file_doc.file_url or "")[1].lower().lstrip(".")
+	return _extract_by_extension(file_doc.get_content(), extension).strip()
 
 
 def _extract_url_source(source) -> list[ExtractedDoc]:

--- a/flow/knowledge/retriever.py
+++ b/flow/knowledge/retriever.py
@@ -28,6 +28,26 @@ CHUNK_DOCTYPE = "AI Knowledge Chunk"
 DEFAULT_LIMIT = 5
 
 
+def retrieve_attachments(query: str, *, session: str, limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
+	"""Best-matching chunks from the files attached to `session`, most relevant first.
+
+	Scoping to `session` is the boundary (enforced upstream by the session-owner check).
+	Returns [{content, score}]; empty on a blank query or when nothing is indexed.
+	"""
+	query = (query or "").strip()
+	if not query or not session:
+		return []
+
+	from flow.knowledge import attachment_store
+	from flow.knowledge.embedder import embed_texts
+
+	search_type = frappe.get_cached_value("AI Knowledge Settings", "AI Knowledge Settings", "search_type")
+	text = query if search_type != "Vector" else None
+
+	(vector,) = embed_texts([query])
+	return attachment_store.search(vector, session=session, text=text, limit=limit)
+
+
 def retrieve(query: str, *, kbs: list[str], limit: int = DEFAULT_LIMIT) -> list[dict[str, Any]]:
 	"""Return the best-matching chunks within `kbs`, most relevant first.
 

--- a/flow/tests/test_ai_api.py
+++ b/flow/tests/test_ai_api.py
@@ -9,7 +9,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from werkzeug.wrappers import Response
 
-from flow.api import resume_run, start_run
+from flow.api import attach_file, resume_run, start_run
 from flow.lib.model import ChatResponse, Model, ToolCall
 from flow.tools.builtins import sync_builtin_tools
 
@@ -433,6 +433,45 @@ class TestStartRunSecurity(IntegrationTestCase):
 		frappe.set_user(_ensure_user("third-ai-user@example.com"))
 		with self.assertRaises(frappe.PermissionError):
 			start_run("steal context", session=theirs["session"])
+
+
+class TestAttachFile(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _file(self, file_name: str = "report.txt", content: str = "report body"):
+		return frappe.get_doc(
+			{"doctype": "File", "file_name": file_name, "content": content, "is_private": 1}
+		).insert()
+
+	def test_attach_file_returns_chip_metadata_and_stages_text(self):
+		from flow.ai.doctype.ai_session_attachment.ai_session_attachment import staged_text
+
+		file_doc = self._file()
+		chip = attach_file(file_doc.name)
+
+		self.assertEqual(chip["file"], file_doc.name)
+		self.assertEqual(chip["file_name"], "report.txt")
+		self.assertNotIn("extracted_text", chip)
+		self.assertEqual(staged_text(file_doc.name), "report body")
+
+	def test_attach_file_strips_and_resolves_input(self):
+		file_doc = self._file()
+		chip = attach_file(f"  {file_doc.name}  ")
+		self.assertEqual(chip["file"], file_doc.name)
+
+	def test_attach_file_rejects_empty_input(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "File is required"):
+			attach_file("")
+
+	def test_attach_file_rejects_whitespace_input(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "File is required"):
+			attach_file("   ")
+
+	def test_attach_file_unsupported_type_surfaces_at_upload(self):
+		file_doc = self._file(file_name="data.bin", content="x")
+		with self.assertRaisesRegex(frappe.ValidationError, "Unsupported file type"):
+			attach_file(file_doc.name)
 
 
 def _ensure_user(email: str) -> str:

--- a/flow/tests/test_ai_api.py
+++ b/flow/tests/test_ai_api.py
@@ -10,6 +10,7 @@ from frappe.tests import IntegrationTestCase
 from werkzeug.wrappers import Response
 
 from flow.api import attach_file, resume_run, start_run
+from flow.api.api import _parse_attachments
 from flow.lib.model import ChatResponse, Model, ToolCall
 from flow.tools.builtins import sync_builtin_tools
 
@@ -586,3 +587,35 @@ def _ensure_user(email: str) -> str:
 	)
 	user.insert(ignore_permissions=True)
 	return email
+
+
+class TestParseAttachments(IntegrationTestCase):
+	def test_empty_values_return_empty_list(self):
+		for value in (None, "", [], "[]"):
+			with self.subTest(value=value):
+				self.assertEqual(_parse_attachments(value), [])
+
+	def test_list_of_ids_passthrough(self):
+		self.assertEqual(_parse_attachments(["a", "b"]), ["a", "b"])
+
+	def test_json_string_array_parsed(self):
+		self.assertEqual(_parse_attachments('["a", "b"]'), ["a", "b"])
+
+	def test_whitespace_stripped(self):
+		self.assertEqual(_parse_attachments(["  a  ", "b\n"]), ["a", "b"])
+
+	def test_invalid_json_rejected(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "Attachments"):
+			_parse_attachments("not json")
+
+	def test_non_list_json_rejected(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "Attachments"):
+			_parse_attachments('{"a": 1}')
+
+	def test_non_string_item_rejected(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "file id"):
+			_parse_attachments(["ok", 123])
+
+	def test_blank_item_rejected(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "file id"):
+			_parse_attachments(["ok", "   "])

--- a/flow/tests/test_ai_api.py
+++ b/flow/tests/test_ai_api.py
@@ -435,6 +435,104 @@ class TestStartRunSecurity(IntegrationTestCase):
 			start_run("steal context", session=theirs["session"])
 
 
+class TestStartRunAttachments(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		sync_builtin_tools()
+
+	def setUp(self):
+		self.model = frappe.get_doc(_model_doc(title="Attach Model")).insert()
+		self.agent = frappe.get_doc(_agent_doc(self.model.name, title="Attach Agent")).insert()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _file(self, file_name: str = "notes.txt", content: str = "the secret code is 1234"):
+		return frappe.get_doc(
+			{"doctype": "File", "file_name": file_name, "content": content, "is_private": 1}
+		).insert()
+
+	def _capture(self):
+		captured: list[list[dict[str, Any]]] = []
+
+		def chat(messages: list[dict[str, Any]], **_: Any) -> ChatResponse:
+			captured.append([dict(m) for m in messages])
+			return _final(f"reply {len(captured)}")
+
+		return captured, chat
+
+	def test_attachment_text_injected_but_stored_clean(self):
+		file_doc = self._file()
+		captured, chat = self._capture()
+		with patch.object(Model, "chat", side_effect=chat):
+			payload = start_run("summarize this", agent=self.agent.name, attachments=[file_doc.name])
+
+		user_msg = [m for m in captured[0] if m["role"] == "user"][-1]
+		self.assertIn("the secret code is 1234", user_msg["content"])
+		self.assertIn("summarize this", user_msg["content"])
+
+		session = frappe.get_doc("AI Session", payload["session"])
+		stored_user = [m for m in session.messages if m.role == "user"][-1]
+		self.assertEqual(stored_user.content, "summarize this")
+
+		self.assertEqual(len(session.attachments), 1)
+		attachment = session.attachments[0]
+		self.assertEqual(attachment.file, file_doc.name)
+		self.assertEqual(attachment.run, payload["name"])
+		self.assertEqual(attachment.extracted_text, "the secret code is 1234")
+
+	def test_attachment_replayed_on_later_turn(self):
+		file_doc = self._file()
+		captured, chat = self._capture()
+		with patch.object(Model, "chat", side_effect=chat):
+			first = start_run("turn one", agent=self.agent.name, attachments=[file_doc.name])
+			start_run("turn two", session=first["session"])
+
+		# File stays in context for the whole conversation: turn one's file is re-sent on turn two.
+		turn_two_users = [m for m in captured[1] if m["role"] == "user"]
+		self.assertEqual(turn_two_users[-1]["content"], "turn two")
+		self.assertIn("the secret code is 1234", turn_two_users[0]["content"])
+
+	def test_attachment_visible_on_resume(self):
+		file_doc = self._file()
+		with patch.object(Model, "chat", return_value=_confirm_call()):
+			paused = start_run("do it", agent=self.agent.name, attachments=[file_doc.name])
+		self.assertEqual(paused["status"], "Paused")
+
+		captured, chat = self._capture()
+		with patch.object(Model, "chat", side_effect=chat):
+			resume_run(paused["name"], {"c1": "Deny"})
+
+		user_msgs = [m for m in captured[0] if m["role"] == "user"]
+		self.assertIn("the secret code is 1234", user_msgs[0]["content"])
+
+	def test_duplicate_attachment_is_recorded_once(self):
+		file_doc = self._file()
+		with patch.object(Model, "chat", return_value=_final()):
+			payload = start_run("hi", agent=self.agent.name, attachments=[file_doc.name, file_doc.name])
+
+		session = frappe.get_doc("AI Session", payload["session"])
+		self.assertEqual(len(session.attachments), 1)
+
+	def test_attachments_accepts_json_string(self):
+		file_doc = self._file()
+		captured, chat = self._capture()
+		with patch.object(Model, "chat", side_effect=chat):
+			start_run("hi", agent=self.agent.name, attachments=json.dumps([file_doc.name]))
+
+		user_msg = [m for m in captured[0] if m["role"] == "user"][-1]
+		self.assertIn("the secret code is 1234", user_msg["content"])
+
+	def test_invalid_attachments_payload_rejected(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "Attachments"):
+			start_run("hi", agent=self.agent.name, attachments="not json")
+
+	def test_unreadable_attachment_aborts_turn(self):
+		with self.assertRaises(frappe.DoesNotExistError):
+			start_run("hi", agent=self.agent.name, attachments=["nonexistent-file-id"])
+
+
 class TestAttachFile(IntegrationTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
@@ -445,7 +543,7 @@ class TestAttachFile(IntegrationTestCase):
 		).insert()
 
 	def test_attach_file_returns_chip_metadata_and_stages_text(self):
-		from flow.ai.doctype.ai_session_attachment.ai_session_attachment import staged_text
+		from flow.ai.doctype.ai_session_attachment.ai_session_attachment import staged_attachment
 
 		file_doc = self._file()
 		chip = attach_file(file_doc.name)
@@ -453,7 +551,7 @@ class TestAttachFile(IntegrationTestCase):
 		self.assertEqual(chip["file"], file_doc.name)
 		self.assertEqual(chip["file_name"], "report.txt")
 		self.assertNotIn("extracted_text", chip)
-		self.assertEqual(staged_text(file_doc.name), "report body")
+		self.assertEqual(staged_attachment(file_doc.name)["extracted_text"], "report body")
 
 	def test_attach_file_strips_and_resolves_input(self):
 		file_doc = self._file()

--- a/flow/tests/test_ai_api.py
+++ b/flow/tests/test_ai_api.py
@@ -9,7 +9,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from werkzeug.wrappers import Response
 
-from flow.api import attach_file, resume_run, start_run
+from flow.api import attach_file, recover_session, resume_run, start_run
 from flow.api.api import _parse_attachments
 from flow.lib.model import ChatResponse, Model, ToolCall
 from flow.tools.builtins import sync_builtin_tools
@@ -619,3 +619,54 @@ class TestParseAttachments(IntegrationTestCase):
 	def test_blank_item_rejected(self):
 		with self.assertRaisesRegex(frappe.ValidationError, "file id"):
 			_parse_attachments(["ok", "   "])
+
+
+class TestRecoverSession(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def _session(self) -> str:
+		return frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True).name
+
+	def _run(self, session: str, status: str, **fields) -> str:
+		return (
+			frappe.get_doc(
+				{"doctype": "AI Run", "session": session, "source": "Manual", "status": status, **fields}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
+	def test_running_run_is_marked_failed(self):
+		session = self._session()
+		run = self._run(session, "Running")
+
+		self.assertEqual(recover_session(session), {"recovered": 1})
+		doc = frappe.get_doc("AI Run", run)
+		self.assertEqual(doc.status, "Failed")
+		self.assertIn("abandoned", doc.error)
+
+	def test_completed_and_paused_runs_untouched(self):
+		session = self._session()
+		completed = self._run(session, "Completed")
+		paused = self._run(session, "Paused", questions=json.dumps([{"key": "c1"}]))
+
+		self.assertEqual(recover_session(session), {"recovered": 0})
+		self.assertEqual(frappe.db.get_value("AI Run", completed, "status"), "Completed")
+		self.assertEqual(frappe.db.get_value("AI Run", paused, "status"), "Paused")
+
+	def test_no_runs_is_noop(self):
+		self.assertEqual(recover_session(self._session()), {"recovered": 0})
+
+	def test_other_users_session_is_rejected(self):
+		session = self._session()
+		self._run(session, "Running")
+
+		frappe.set_user(_ensure_user("recover-other-user@example.com"))
+		with self.assertRaises(frappe.PermissionError):
+			recover_session(session)
+
+	def test_blank_session_raises(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "required"):
+			recover_session("  ")

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -1154,6 +1154,23 @@ class TestAttachmentStore(IntegrationTestCase):
 		with self.assertRaises(ValueError):
 			attachment_store.delete()
 
+	def test_delete_by_session_list(self):
+		self._seed()
+		attachment_store.delete(session=["SES-a", "SES-b"])
+		self.assertEqual(attachment_store.search([1.0, 0.0, 0.0, 0.0], session="SES-a", limit=5), [])
+		self.assertEqual(attachment_store.search([0.9, 0.1, 0.0, 0.0], session="SES-b", limit=5), [])
+
+	def test_delete_session_list_leaves_others(self):
+		self._seed()
+		attachment_store.delete(session=["SES-a"])
+		self.assertEqual(attachment_store.search([1.0, 0.0, 0.0, 0.0], session="SES-a", limit=5), [])
+		self.assertTrue(attachment_store.search([0.9, 0.1, 0.0, 0.0], session="SES-b", limit=5))
+
+	def test_delete_empty_session_list_is_noop(self):
+		self._seed()
+		attachment_store.delete(session=[])
+		self.assertTrue(attachment_store.search([0.9, 0.1, 0.0, 0.0], session="SES-b", limit=5))
+
 
 class TestRetrieveAttachments(IntegrationTestCase):
 	def setUp(self):

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from flow.knowledge import Knowledge, store
+from flow.knowledge import Knowledge, attachment_store, store
 from flow.knowledge.chunker import chunk_text
 from flow.knowledge.embedder import embed_texts, probe_dimension
 from flow.knowledge.extract import (
@@ -26,7 +26,7 @@ from flow.knowledge.ingest import (
 	reconcile_source,
 	sync_due_sources,
 )
-from flow.knowledge.retriever import retrieve
+from flow.knowledge.retriever import retrieve, retrieve_attachments
 
 DIM = 4
 
@@ -1078,3 +1078,135 @@ class TestAgentKnowledge(IntegrationTestCase):
 		with patch("flow.knowledge.retriever.retrieve", return_value=[]) as mock:
 			search(query="hi")
 		mock.assert_called_once_with("hi", kbs=[first.name, second.name])
+
+
+class TestAttachmentStore(IntegrationTestCase):
+	def setUp(self):
+		attachment_store.drop_table()
+
+	def tearDown(self):
+		attachment_store.drop_table()
+
+	def _seed(self):
+		attachment_store.ensure_table(DIM)
+		attachment_store.add(
+			"SES-a",
+			"ATT-1",
+			["wifi not connecting on macbook", "printer not detected on windows"],
+			[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+		)
+		attachment_store.add("SES-b", "ATT-2", ["how to set up your laptop"], [[0.9, 0.1, 0.0, 0.0]])
+
+	def test_ensure_table_idempotent(self):
+		attachment_store.ensure_table(DIM)
+		attachment_store.ensure_table(DIM)
+		self.assertTrue(attachment_store._table_exists())
+
+	def test_ensure_table_recreates_on_dimension_change(self):
+		self._seed()
+		attachment_store.ensure_table(DIM + 1)  # different width -> dropped and recreated
+		self.assertEqual(attachment_store._open_table().count_rows(), 0)
+
+	def test_ensure_table_rejects_invalid_dimension(self):
+		with self.assertRaises(ValueError):
+			attachment_store.ensure_table(0)
+
+	def test_add_length_mismatch_raises(self):
+		attachment_store.ensure_table(DIM)
+		with self.assertRaises(ValueError):
+			attachment_store.add("SES-a", "ATT-1", ["one", "two"], [[1.0, 0.0, 0.0, 0.0]])
+
+	def test_search_before_table_returns_empty(self):
+		self.assertEqual(attachment_store.search([1.0, 0.0, 0.0, 0.0], session="SES-a"), [])
+
+	def test_search_requires_session(self):
+		self._seed()
+		with self.assertRaises(ValueError):
+			attachment_store.search([1.0, 0.0, 0.0, 0.0], session="")
+
+	def test_vector_search_scopes_to_session(self):
+		self._seed()
+		hits = attachment_store.search([1.0, 0.0, 0.0, 0.0], session="SES-a", limit=5)
+		self.assertTrue(hits)
+		self.assertTrue(all("laptop" not in h["content"] for h in hits))  # SES-b not leaked
+
+	def test_search_excludes_other_sessions(self):
+		self._seed()
+		hits = attachment_store.search([0.9, 0.1, 0.0, 0.0], session="SES-b", limit=5)
+		self.assertEqual([h["content"] for h in hits], ["how to set up your laptop"])
+
+	def test_hybrid_search_surfaces_keyword(self):
+		self._seed()
+		hits = attachment_store.search([1.0, 0.0, 0.0, 0.0], session="SES-a", text="printer", limit=2)
+		self.assertTrue(any("printer" in h["content"] for h in hits))
+
+	def test_delete_by_attachment(self):
+		self._seed()
+		attachment_store.delete(session="SES-a", attachment="ATT-1")
+		self.assertEqual(attachment_store.search([1.0, 0.0, 0.0, 0.0], session="SES-a", limit=5), [])
+
+	def test_delete_by_session(self):
+		self._seed()
+		attachment_store.delete(session="SES-b")
+		self.assertEqual(attachment_store.search([0.9, 0.1, 0.0, 0.0], session="SES-b", limit=5), [])
+
+	def test_delete_requires_a_criterion(self):
+		with self.assertRaises(ValueError):
+			attachment_store.delete()
+
+
+class TestRetrieveAttachments(IntegrationTestCase):
+	def setUp(self):
+		attachment_store.drop_table()
+		self.model = _make_model()
+		_set_settings(embedding_model=self.model.name, embedding_dimension=DIM, search_type="Hybrid")
+		attachment_store.ensure_table(DIM)
+		attachment_store.add(
+			"SES-x",
+			"ATT-1",
+			["the refund policy allows returns within thirty days"],
+			[[1.0, 0.0, 0.0, 0.0]],
+		)
+
+	def tearDown(self):
+		attachment_store.drop_table()
+		frappe.db.rollback()
+
+	def _fake_embed(self, input, **kwargs):
+		return _embedding_response([[1.0, 0.0, 0.0, 0.0]] * len(input))
+
+	def test_retrieve_returns_scoped_content(self):
+		with patch("litellm.embedding", side_effect=self._fake_embed):
+			results = retrieve_attachments("refund", session="SES-x")
+		self.assertTrue(results)
+		self.assertIn("refund", results[0]["content"])
+
+	def test_retrieve_blank_query_returns_empty(self):
+		with patch("litellm.embedding") as mocked:
+			self.assertEqual(retrieve_attachments("   ", session="SES-x"), [])
+		mocked.assert_not_called()  # no embedding call for an empty query
+
+	def test_retrieve_requires_session(self):
+		self.assertEqual(retrieve_attachments("refund", session=""), [])
+
+	def test_retrieve_other_session_finds_nothing(self):
+		with patch("litellm.embedding", side_effect=self._fake_embed):
+			self.assertEqual(retrieve_attachments("refund", session="SES-other"), [])
+
+	def test_search_type_vector_skips_text(self):
+		_set_settings(search_type="Vector")
+		with (
+			patch("litellm.embedding", side_effect=self._fake_embed),
+			patch.object(attachment_store, "search", return_value=[]) as mocked,
+		):
+			retrieve_attachments("refund", session="SES-x")
+		self.assertIsNone(mocked.call_args.kwargs["text"])  # Vector mode -> no FTS text
+
+	def test_search_type_hybrid_passes_text(self):
+		_set_settings(search_type="Hybrid")
+		with (
+			patch("litellm.embedding", side_effect=self._fake_embed),
+			patch.object(attachment_store, "search", return_value=[]) as mocked,
+		):
+			retrieve_attachments("refund", session="SES-x")
+		self.assertEqual(mocked.call_args.kwargs["text"], "refund")

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -28,6 +28,10 @@ export const getPausedRun = (session) =>
 		limit: 1,
 	});
 
+// Fail any Running run left behind by a stream that was cut off (refresh/navigation),
+// so a reloaded session isn't blocked from starting the next turn.
+export const recoverSession = (session) => frappe.xcall("flow.api.recover_session", { session });
+
 // Upload a file as private, returning the created File doc. The chat attachment
 // flow needs the File name to stage it via attachFile.
 export async function uploadFile(file) {

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -27,3 +27,34 @@ export const getPausedRun = (session) =>
 		order_by: "creation desc",
 		limit: 1,
 	});
+
+// Upload a file as private, returning the created File doc. The chat attachment
+// flow needs the File name to stage it via attachFile.
+export async function uploadFile(file) {
+	const form = new FormData();
+	form.append("file", file, file.name);
+	form.append("is_private", "1");
+
+	const resp = await fetch("/api/method/upload_file", {
+		method: "POST",
+		headers: { "X-Frappe-CSRF-Token": frappe.csrf_token },
+		body: form,
+	});
+	const data = await resp.json().catch(() => ({}));
+	if (!resp.ok) throw new Error(serverMessage(data) || `Upload failed (${resp.status})`);
+	return data.message;
+}
+
+// Validate and stage an uploaded File for use as a chat attachment. Returns chip
+// metadata; throws (unsupported type, unreadable, …) which surfaces on the chip.
+export const attachFile = (file) => frappe.xcall("flow.api.attach_file", { file });
+
+function serverMessage(data) {
+	try {
+		const msgs = JSON.parse(data._server_messages || "[]");
+		if (msgs.length) return JSON.parse(msgs[0]).message;
+	} catch {
+		// fall through to other error fields
+	}
+	return data.exception || data._error_message || null;
+}

--- a/frontend/src/components/AttachmentChip.vue
+++ b/frontend/src/components/AttachmentChip.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { computed } from "vue";
+import { FeatherIcon, Spinner } from "@/lib/ui";
+import { __ } from "@/lib/translate";
+
+const props = defineProps({
+	fileName: { type: String, default: "" },
+	fileSize: { type: Number, default: 0 },
+	status: { type: String, default: "ready" }, // uploading | ready | error
+	error: { type: String, default: "" },
+	removable: { type: Boolean, default: false },
+});
+defineEmits(["remove"]);
+
+const sizeLabel = computed(() => {
+	const b = props.fileSize || 0;
+	if (b < 1024) return `${b} B`;
+	if (b < 1024 * 1024) return `${Math.round(b / 1024)} KB`;
+	return `${(b / (1024 * 1024)).toFixed(1)} MB`;
+});
+
+const title = computed(() =>
+	props.status === "error" ? props.error || __("Couldn't attach file") : props.fileName
+);
+</script>
+
+<template>
+	<div
+		class="flex max-w-[200px] items-center gap-1.5 rounded-lg border bg-surface-gray-1 py-1 pl-2 pr-1.5"
+		:class="status === 'error' ? 'border-outline-red-2' : 'border-outline-gray-2'"
+		:title="title"
+	>
+		<FeatherIcon name="file-text" class="h-3.5 w-3.5 shrink-0 text-ink-gray-5" />
+		<div class="min-w-0 flex-1">
+			<div class="truncate text-[12px] font-medium leading-tight text-ink-gray-8">
+				{{ fileName }}
+			</div>
+			<div class="text-[10.5px] leading-tight text-ink-gray-5">
+				<span v-if="status === 'error'" class="text-ink-red-3">{{ __("Failed") }}</span>
+				<span v-else-if="status === 'uploading'">{{ __("Uploading…") }}</span>
+				<span v-else>{{ sizeLabel }}</span>
+			</div>
+		</div>
+		<Spinner v-if="status === 'uploading'" class="h-3.5 w-3.5 shrink-0 text-ink-gray-5" />
+		<button
+			v-else-if="removable"
+			class="flex h-4 w-4 shrink-0 items-center justify-center rounded text-ink-gray-5 hover:bg-surface-gray-3 hover:text-ink-gray-7"
+			:title="__('Remove')"
+			@click="$emit('remove')"
+		>
+			<FeatherIcon name="x" class="h-3 w-3" />
+		</button>
+	</div>
+</template>

--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -172,7 +172,6 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 							:title="__('Agent')"
 							@click="toggle"
 						>
-							<span class="h-1.5 w-1.5 rounded-full bg-surface-green-3"></span>
 							<span class="font-medium text-ink-gray-8">{{
 								agentLabel(selectedAgent)
 							}}</span>

--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, watch, nextTick } from "vue";
 import PanelDropdown from "./PanelDropdown.vue";
+import AttachmentChip from "./AttachmentChip.vue";
 import { Button, FeatherIcon } from "@/lib/ui";
 import { useStore } from "@/store";
 import { __ } from "@/lib/translate";
@@ -10,20 +11,31 @@ const {
 	models,
 	selectedAgent,
 	selectedModel,
+	attachments,
 	sending,
 	paused,
 	locked,
 	needsSetup,
+	uploading,
 	focusTick,
 	agentLabel,
 	modelLabel,
 	setAgent,
 	setModel,
 	send,
+	attachFiles,
+	removeAttachment,
 } = useStore();
+
+const ACCEPT =
+	".pdf,.xlsx,.docx,.html,.htm,.txt,.text,.md,.markdown,.csv,.tsv,.log,.rst,.json,.yaml,.yml";
 
 const text = ref("");
 const el = ref(null);
+const fileInput = ref(null);
+const dragging = ref(false);
+
+const inputDisabled = computed(() => sending.value || paused.value || needsSetup.value);
 
 const agentItems = computed(() => agents.value.map((a) => ({ value: a.name, label: a.title })));
 const modelItems = computed(() => [
@@ -32,7 +44,12 @@ const modelItems = computed(() => [
 ]);
 
 const canSend = computed(
-	() => text.value.trim() && !sending.value && !paused.value && !needsSetup.value
+	() =>
+		text.value.trim() &&
+		!sending.value &&
+		!paused.value &&
+		!needsSetup.value &&
+		!uploading.value
 );
 const placeholder = computed(() =>
 	needsSetup.value ? __("Setup required…") : __("Ask {0}…", [agentLabel(selectedAgent.value)])
@@ -43,6 +60,33 @@ function submit() {
 	send(text.value);
 	text.value = "";
 	resize();
+}
+
+function pickFiles() {
+	fileInput.value?.click();
+}
+
+function onFilesPicked(e) {
+	attachFiles(e.target.files);
+	e.target.value = ""; // allow re-picking the same file
+}
+
+function onDragOver(e) {
+	if (inputDisabled.value) return;
+	e.preventDefault();
+	dragging.value = true;
+}
+
+function onDragLeave(e) {
+	if (e.currentTarget.contains(e.relatedTarget)) return;
+	dragging.value = false;
+}
+
+function onDrop(e) {
+	e.preventDefault();
+	dragging.value = false;
+	if (inputDisabled.value) return;
+	attachFiles(e.dataTransfer.files);
 }
 
 function onKeydown(e) {
@@ -65,8 +109,25 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 <template>
 	<div class="border-t border-outline-gray-1 px-4 pb-3.5 pt-2.5">
 		<div
-			class="flow-composer mx-auto flex w-full max-w-3xl flex-col gap-1.5 rounded-xl border border-outline-gray-2 bg-surface-white px-2.5 py-2 shadow-sm"
+			class="flow-composer mx-auto flex w-full max-w-3xl flex-col gap-1.5 rounded-xl border bg-surface-white px-2.5 py-2 shadow-sm transition-colors"
+			:class="dragging ? 'border-outline-gray-4 bg-surface-gray-1' : 'border-outline-gray-2'"
+			@dragover="onDragOver"
+			@dragleave="onDragLeave"
+			@drop="onDrop"
 		>
+			<div v-if="attachments.length" class="flex flex-wrap gap-1.5">
+				<AttachmentChip
+					v-for="a in attachments"
+					:key="a.uid"
+					:file-name="a.file_name"
+					:file-size="a.file_size"
+					:status="a.status"
+					:error="a.error"
+					removable
+					@remove="removeAttachment(a.uid)"
+				/>
+			</div>
+
 			<textarea
 				ref="el"
 				v-model="text"
@@ -79,6 +140,24 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 			></textarea>
 
 			<div class="flex items-center gap-1.5">
+				<!-- attach -->
+				<button
+					class="flex h-6 w-6 items-center justify-center rounded text-ink-gray-6 hover:bg-surface-gray-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
+					:disabled="inputDisabled"
+					:title="__('Attach file')"
+					@click="pickFiles"
+				>
+					<FeatherIcon name="paperclip" class="h-3.5 w-3.5" />
+				</button>
+				<input
+					ref="fileInput"
+					type="file"
+					multiple
+					:accept="ACCEPT"
+					class="hidden"
+					@change="onFilesPicked"
+				/>
+
 				<!-- agent -->
 				<PanelDropdown
 					:items="agentItems"

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -44,7 +44,11 @@ watch(scrollTick, () => {
 			/>
 
 			<template v-for="msg in messages" :key="msg.id">
-				<UserMessage v-if="msg.role === 'user'" :content="msg.content" />
+				<UserMessage
+					v-if="msg.role === 'user'"
+					:content="msg.content"
+					:attachments="msg.attachments"
+				/>
 				<AssistantMessage v-else :message="msg" />
 			</template>
 		</div>

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -3,7 +3,9 @@ import { ref, watch } from "vue";
 import UserMessage from "./UserMessage.vue";
 import AssistantMessage from "./AssistantMessage.vue";
 import EmptyState from "./EmptyState.vue";
+import { FeatherIcon } from "@/lib/ui";
 import { useStore } from "@/store";
+import { __ } from "@/lib/translate";
 
 const { messages, needsSetup, agents, models, scrollTick } = useStore();
 
@@ -44,11 +46,16 @@ watch(scrollTick, () => {
 			/>
 
 			<template v-for="msg in messages" :key="msg.id">
-				<UserMessage
-					v-if="msg.role === 'user'"
-					:content="msg.content"
-					:attachments="msg.attachments"
-				/>
+				<template v-if="msg.role === 'user'">
+					<UserMessage :content="msg.content" :attachments="msg.attachments" />
+					<div
+						v-if="msg.interrupted"
+						class="flex items-center gap-1.5 text-[length:var(--text-sm)] text-ink-gray-5"
+					>
+						<FeatherIcon name="alert-circle" class="h-3.5 w-3.5 shrink-0" />
+						{{ __("Response interrupted") }}
+					</div>
+				</template>
 				<AssistantMessage v-else :message="msg" />
 			</template>
 		</div>

--- a/frontend/src/components/PanelDropdown.vue
+++ b/frontend/src/components/PanelDropdown.vue
@@ -37,7 +37,7 @@ function select(item) {
 				<button
 					v-for="item in items"
 					:key="item.value ?? '__default'"
-					class="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-ink-gray-8 hover:bg-surface-gray-2"
+					class="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-xs text-ink-gray-8 hover:bg-surface-gray-2"
 					:class="{ 'bg-surface-gray-2': item.value === modelValue }"
 					@click="select(item)"
 				>

--- a/frontend/src/components/UserMessage.vue
+++ b/frontend/src/components/UserMessage.vue
@@ -1,9 +1,22 @@
 <script setup>
-defineProps({ content: { type: String, default: "" } });
+import AttachmentChip from "./AttachmentChip.vue";
+
+defineProps({
+	content: { type: String, default: "" },
+	attachments: { type: Array, default: () => [] },
+});
 </script>
 
 <template>
-	<div class="flex justify-end">
+	<div class="flex flex-col items-end gap-1.5">
+		<div v-if="attachments.length" class="flex max-w-[88%] flex-wrap justify-end gap-1.5">
+			<AttachmentChip
+				v-for="(a, i) in attachments"
+				:key="`${a.file_name}-${i}`"
+				:file-name="a.file_name"
+				:file-size="a.file_size"
+			/>
+		</div>
 		<div
 			class="max-w-[88%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-surface-gray-2 px-3.5 py-2.5 text-[length:var(--text-base)] font-normal leading-relaxed text-ink-gray-9"
 		>

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -125,6 +125,10 @@ async function switchSession(name) {
 	messages.value = [];
 	attachments.value = [];
 
+	// A prior stream cut off mid-flight may have left a Running run; clear it so the
+	// reloaded session can start a new turn instead of being blocked.
+	await api.recoverSession(name).catch(() => {});
+
 	const doc = await api.getSession(name);
 	selectedAgent.value = doc.agent;
 	selectedModel.value = doc.model || null;
@@ -173,6 +177,16 @@ async function switchSession(name) {
 			if (part) part.result = m.content;
 		}
 	}
+
+	// A turn whose stream died before persisting a reply leaves a user message with
+	// no assistant message after it; flag it so the UI notes the interruption rather
+	// than showing a bare, unanswered bubble.
+	const built = messages.value;
+	for (let i = 0; i < built.length; i++) {
+		if (built[i].role === "user" && built[i + 1]?.role !== "assistant")
+			built[i].interrupted = true;
+	}
+
 	requestScroll();
 	await restorePausedRun(name);
 }

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -7,6 +7,8 @@ import { startRun, resumeRun } from "@/api/stream";
 
 let uid = 0;
 const nextId = () => `n${++uid}`;
+let auid = 0;
+const nextAttachmentId = () => `a${++auid}`;
 
 // ── state ───────────────────────────────────────────────────────────────────
 const agents = ref([]);
@@ -19,6 +21,9 @@ const sessionName = ref(null);
 const runName = ref(null);
 
 const messages = ref([]);
+// Composer attachments staged for the next turn: { uid, file, file_name, file_size, status, error }.
+// status: "uploading" | "ready" | "error".
+const attachments = ref([]);
 const sending = ref(false);
 const loaded = ref(false);
 const fullscreen = ref(false);
@@ -30,6 +35,7 @@ const focusTick = ref(0);
 // ── derived ───────────────────────────────────────────────────────────────
 const locked = computed(() => messages.value.length > 0);
 const needsSetup = computed(() => loaded.value && (!agents.value.length || !models.value.length));
+const uploading = computed(() => attachments.value.some((a) => a.status === "uploading"));
 const paused = computed(() => {
 	const last = messages.value[messages.value.length - 1];
 	return Boolean(last?.questions?.length);
@@ -73,7 +79,43 @@ function newChat() {
 	sessionName.value = null;
 	runName.value = null;
 	messages.value = [];
+	attachments.value = [];
 	focusTick.value++;
+}
+
+// ── attachments ────────────────────────────────────────────────────────────────
+function attachFiles(fileList) {
+	for (const f of Array.from(fileList || [])) {
+		const length = attachments.value.push({
+			uid: nextAttachmentId(),
+			file: null,
+			file_name: f.name,
+			file_size: f.size,
+			status: "uploading",
+			error: "",
+		});
+		// Grab the reactive proxy (not the raw object) so the async mutations below
+		// trigger updates; uploads run concurrently.
+		uploadAndStage(f, attachments.value[length - 1]);
+	}
+}
+
+async function uploadAndStage(f, item) {
+	try {
+		const uploaded = await api.uploadFile(f);
+		const chip = await api.attachFile(uploaded.name);
+		item.file = chip.file;
+		item.file_name = chip.file_name;
+		item.file_size = chip.file_size;
+		item.status = "ready";
+	} catch (e) {
+		item.status = "error";
+		item.error = e?.message || "";
+	}
+}
+
+function removeAttachment(uid) {
+	attachments.value = attachments.value.filter((a) => a.uid !== uid);
 }
 
 async function switchSession(name) {
@@ -81,15 +123,28 @@ async function switchSession(name) {
 	sessionName.value = name;
 	runName.value = null;
 	messages.value = [];
+	attachments.value = [];
 
 	const doc = await api.getSession(name);
 	selectedAgent.value = doc.agent;
 	selectedModel.value = doc.model || null;
 
+	// Attachments are linked to their turn by run; group so each user message
+	// can render its own chips.
+	const attachmentsByRun = {};
+	for (const a of doc.attachments || []) {
+		(attachmentsByRun[a.run] ||= []).push({ file_name: a.file_name, file_size: a.file_size });
+	}
+
 	let current = null;
 	for (const m of doc.messages || []) {
 		if (m.role === "user") {
-			messages.value.push({ id: nextId(), role: "user", content: m.content });
+			messages.value.push({
+				id: nextId(),
+				role: "user",
+				content: m.content,
+				attachments: attachmentsByRun[m.run] || [],
+			});
 		} else if (m.role === "assistant") {
 			const parts = [];
 			if (m.content) parts.push({ id: nextId(), type: "text", text: m.content });
@@ -139,9 +194,14 @@ async function restorePausedRun(session) {
 // ── sending / streaming ────────────────────────────────────────────────────────
 async function send(text) {
 	text = text.trim();
-	if (!text || sending.value || paused.value) return;
+	if (!text || sending.value || paused.value || uploading.value) return;
 
-	messages.value.push({ id: nextId(), role: "user", content: text });
+	const ready = attachments.value.filter((a) => a.status === "ready");
+	const files = ready.map((a) => a.file);
+	const chips = ready.map((a) => ({ file_name: a.file_name, file_size: a.file_size }));
+	attachments.value = [];
+
+	messages.value.push({ id: nextId(), role: "user", content: text, attachments: chips });
 	const assistant = pushAssistant();
 	sending.value = true;
 	requestScroll();
@@ -150,6 +210,7 @@ async function send(text) {
 		await startRun(
 			{
 				input: text,
+				...(files.length && { attachments: files }),
 				...(sessionName.value && { session: sessionName.value }),
 				...(selectedAgent.value && !sessionName.value && { agent: selectedAgent.value }),
 				...(selectedModel.value && { model: selectedModel.value }),
@@ -316,6 +377,7 @@ export function useStore() {
 		selectedModel,
 		sessionName,
 		messages,
+		attachments,
 		sending,
 		loaded,
 		fullscreen,
@@ -325,6 +387,7 @@ export function useStore() {
 		locked,
 		needsSetup,
 		paused,
+		uploading,
 		agentLabel,
 		modelLabel,
 		// actions
@@ -336,5 +399,7 @@ export function useStore() {
 		switchSession,
 		send,
 		answerQuestion,
+		attachFiles,
+		removeAttachment,
 	};
 }


### PR DESCRIPTION
## Summary

Adds end-to-end file attachment support for chat sessions — UI upload, server-side extraction, context-aware routing, and ephemeral retrieval for oversized files.

## What was built

### Phase 1 — Extract reuse
`extract_file` was extracted from the knowledge ingestion pipeline into a shared helper so both the knowledge source path and the new chat attachment path use the same extraction logic (PDF, DOCX, plain text, etc.).

### Phase 2 — Attachment API and doctype
A new `AI Session Attachment` child table stores per-turn attachments: the file reference, extracted text, file size, and a `mode` field (`Inline` or `Retrieval`). Two new API endpoints are added:
- `attach_file(file)` — validates ownership, extracts text, and stages it in cache at upload time so errors surface before the user sends their message.
- `start_run` now accepts an `attachments` list of file names to associate with a turn.

### Phase 3 — Frontend
A paperclip button and drag-drop on the composer allow attaching files. Attachment state is managed in the panel store. Attached files render as dismissible chips on the composer and as read-only chips on sent messages.

### Phase 4 — Token-budget routing and ephemeral retrieval

**Context window field on AI Model.** A `context_window` Int field was added to AI Model. On save, if the field is empty or the model ID changed, litellm's `get_model_info` is called to auto-detect the value. A manually set value is preserved unless the model ID changes.

**Routing.** Each attachment is stamped `Inline` or `Retrieval` when the turn is persisted. Files whose extracted text fits within half the model's context window (in characters, `window × 4 × 0.5`) are routed `Inline`. Oversized files are routed `Retrieval` if an embedding model is configured, otherwise they fall back to `Inline` with truncation.

**Ephemeral vector store.** A new `chat_attachment_chunks` LanceDB table (separate from the curated KB `chunks` table) stores session-scoped chunks for retrieval-mode attachments. The separation ensures chat files never surface in agent knowledge-base search. Vector and FTS indices are maintained via the same helpers used by the curated store.

**Indexing.** After a turn is persisted, retrieval-mode attachments are chunked and embedded into the ephemeral store. On any failure (empty text, provider error) the row is demoted to `Inline` so the turn always proceeds.

**Prompt building.** `_build_prompt_messages` augments the transcript ephemerally at call time — stored messages are never modified. Inline file bodies are re-injected on their turn, clamped to a remaining-aware budget (`window − reserved_output − dialogue_length`). Retrieval files get a short note on their turn; on the latest turn the top-8 most relevant chunks (hybrid search, honoring the `search_type` setting) are injected. The budget is shared between inline bodies and retrieved chunks so they cannot collectively overflow the window.

**Cleanup.** `on_trash` purges a session's chunks from the ephemeral store. `clear_old_logs` (bulk SQL path, which does not fire controller hooks) explicitly deletes `AI Session Attachment` rows and purges chunks per batch. Cleanup failures are logged but never block session deletion.

## Key design decisions

- **Injection-only, no search tool.** Retrieved chunks are injected directly into the user turn rather than exposed as an LLM-callable tool. This matches how agno handles file attachments natively and avoids adding a second search tool alongside `search_knowledge`.
- **Two-store separation.** Chat attachment chunks and curated KB chunks live in different LanceDB tables. A session-scoped WHERE clause is the inner guard; the `_assert_session_owner` check in `load_session` is the authorization boundary.
- **Budget is occupancy-aware, not a fixed fraction.** The injection budget shrinks as the conversation grows, so inline files yield to dialogue rather than overflowing the window. The budget is a stopgap until compaction is implemented.
- **Retrieval-mode routing does not re-evaluate per turn.** The inline/retrieval decision is made once at persist time and stored on the row. Per-turn re-evaluation is unnecessary because the file content does not change.