### PR TITLE
fix: chat bubble link overflow and composer font weight

### DIFF
--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -73,7 +73,7 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 				rows="1"
 				:placeholder="placeholder"
 				:disabled="sending || paused || needsSetup"
-				class="max-h-40 min-h-[22px] w-full resize-none border-0 bg-transparent text-base leading-relaxed text-ink-gray-9 outline-none placeholder:text-ink-gray-4"
+				class="max-h-40 min-h-[22px] w-full resize-none border-0 bg-transparent text-base font-normal leading-relaxed text-ink-gray-9 outline-none placeholder:text-ink-gray-4"
 				@keydown="onKeydown"
 				@input="resize"
 			></textarea>

--- a/frontend/src/components/UserMessage.vue
+++ b/frontend/src/components/UserMessage.vue
@@ -5,7 +5,7 @@ defineProps({ content: { type: String, default: "" } });
 <template>
 	<div class="flex justify-end">
 		<div
-			class="max-w-[88%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-surface-gray-2 px-3.5 py-2.5 text-[length:var(--text-base)] font-normal leading-relaxed text-ink-gray-9"
+			class="max-w-[88%] whitespace-pre-wrap break-words rounded-2xl rounded-br-md bg-surface-gray-2 px-3.5 py-2.5 text-[length:var(--text-base)] font-normal leading-relaxed text-ink-gray-9"
 		>
 			{{ content }}
 		</div>


### PR DESCRIPTION
- Add `break-words` to user message bubble so long URLs wrap instead of overflow
- Add `font-normal` to composer textarea to match the rest of the chat UI