### PR TITLE
fix: recover abandoned runs and surface interrupted turns

### DIFF
--- a/flow/api/__init__.py
+++ b/flow/api/__init__.py
@@ -1,4 +1,4 @@
 # Re-exported so whitelisted endpoints stay reachable at flow.api.<name>.
-from flow.api.api import attach_file, resume_run, start_run
+from flow.api.api import attach_file, recover_session, resume_run, start_run
 
-__all__ = ["attach_file", "resume_run", "start_run"]
+__all__ = ["attach_file", "recover_session", "resume_run", "start_run"]

--- a/flow/api/api.py
+++ b/flow/api/api.py
@@ -63,6 +63,29 @@ def resume_run(
 
 
 @frappe.whitelist()
+def recover_session(session: str) -> dict[str, int]:
+	"""Fail any Running run on session (re)load. The client that owned the stream is
+	gone, so the run is abandoned; clearing it here unblocks the next turn instead of
+	waiting for the stale-run timeout on the next send."""
+	if not isinstance(session, str) or not session.strip():
+		frappe.throw(_("Session is required."), title=_("Invalid Session"))
+
+	from flow.lib.session import _assert_session_owner
+
+	doc = frappe.get_doc("AI Session", session.strip())
+	_assert_session_owner(doc)
+
+	abandoned = frappe.get_all("AI Run", filters={"session": doc.name, "status": "Running"}, pluck="name")
+	for name in abandoned:
+		frappe.db.set_value(
+			"AI Run",
+			name,
+			{"status": "Failed", "error": "Run abandoned: stream ended without completing."},
+		)
+	return {"recovered": len(abandoned)}
+
+
+@frappe.whitelist()
 def attach_file(file: str) -> dict[str, Any]:
 	"""Validate and extract an uploaded File for use as a chat attachment. Errors
 	(unsupported type, unreadable, not owned) surface here, at upload time. The

--- a/flow/tests/test_ai_api.py
+++ b/flow/tests/test_ai_api.py
@@ -9,7 +9,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from werkzeug.wrappers import Response
 
-from flow.api import attach_file, resume_run, start_run
+from flow.api import attach_file, recover_session, resume_run, start_run
 from flow.api.api import _parse_attachments
 from flow.lib.model import ChatResponse, Model, ToolCall
 from flow.tools.builtins import sync_builtin_tools
@@ -619,3 +619,54 @@ class TestParseAttachments(IntegrationTestCase):
 	def test_blank_item_rejected(self):
 		with self.assertRaisesRegex(frappe.ValidationError, "file id"):
 			_parse_attachments(["ok", "   "])
+
+
+class TestRecoverSession(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def _session(self) -> str:
+		return frappe.get_doc({"doctype": "AI Session"}).insert(ignore_permissions=True).name
+
+	def _run(self, session: str, status: str, **fields) -> str:
+		return (
+			frappe.get_doc(
+				{"doctype": "AI Run", "session": session, "source": "Manual", "status": status, **fields}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
+	def test_running_run_is_marked_failed(self):
+		session = self._session()
+		run = self._run(session, "Running")
+
+		self.assertEqual(recover_session(session), {"recovered": 1})
+		doc = frappe.get_doc("AI Run", run)
+		self.assertEqual(doc.status, "Failed")
+		self.assertIn("abandoned", doc.error)
+
+	def test_completed_and_paused_runs_untouched(self):
+		session = self._session()
+		completed = self._run(session, "Completed")
+		paused = self._run(session, "Paused", questions=json.dumps([{"key": "c1"}]))
+
+		self.assertEqual(recover_session(session), {"recovered": 0})
+		self.assertEqual(frappe.db.get_value("AI Run", completed, "status"), "Completed")
+		self.assertEqual(frappe.db.get_value("AI Run", paused, "status"), "Paused")
+
+	def test_no_runs_is_noop(self):
+		self.assertEqual(recover_session(self._session()), {"recovered": 0})
+
+	def test_other_users_session_is_rejected(self):
+		session = self._session()
+		self._run(session, "Running")
+
+		frappe.set_user(_ensure_user("recover-other-user@example.com"))
+		with self.assertRaises(frappe.PermissionError):
+			recover_session(session)
+
+	def test_blank_session_raises(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "required"):
+			recover_session("  ")

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -28,6 +28,10 @@ export const getPausedRun = (session) =>
 		limit: 1,
 	});
 
+// Fail any Running run left behind by a stream that was cut off (refresh/navigation),
+// so a reloaded session isn't blocked from starting the next turn.
+export const recoverSession = (session) => frappe.xcall("flow.api.recover_session", { session });
+
 // Upload a file as private, returning the created File doc. The chat attachment
 // flow needs the File name to stage it via attachFile.
 export async function uploadFile(file) {

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -3,7 +3,9 @@ import { ref, watch } from "vue";
 import UserMessage from "./UserMessage.vue";
 import AssistantMessage from "./AssistantMessage.vue";
 import EmptyState from "./EmptyState.vue";
+import { FeatherIcon } from "@/lib/ui";
 import { useStore } from "@/store";
+import { __ } from "@/lib/translate";
 
 const { messages, needsSetup, agents, models, scrollTick } = useStore();
 
@@ -44,11 +46,16 @@ watch(scrollTick, () => {
 			/>
 
 			<template v-for="msg in messages" :key="msg.id">
-				<UserMessage
-					v-if="msg.role === 'user'"
-					:content="msg.content"
-					:attachments="msg.attachments"
-				/>
+				<template v-if="msg.role === 'user'">
+					<UserMessage :content="msg.content" :attachments="msg.attachments" />
+					<div
+						v-if="msg.interrupted"
+						class="flex items-center gap-1.5 text-[length:var(--text-sm)] text-ink-gray-5"
+					>
+						<FeatherIcon name="alert-circle" class="h-3.5 w-3.5 shrink-0" />
+						{{ __("Response interrupted") }}
+					</div>
+				</template>
 				<AssistantMessage v-else :message="msg" />
 			</template>
 		</div>

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -125,6 +125,10 @@ async function switchSession(name) {
 	messages.value = [];
 	attachments.value = [];
 
+	// A prior stream cut off mid-flight may have left a Running run; clear it so the
+	// reloaded session can start a new turn instead of being blocked.
+	await api.recoverSession(name).catch(() => {});
+
 	const doc = await api.getSession(name);
 	selectedAgent.value = doc.agent;
 	selectedModel.value = doc.model || null;
@@ -173,6 +177,16 @@ async function switchSession(name) {
 			if (part) part.result = m.content;
 		}
 	}
+
+	// A turn whose stream died before persisting a reply leaves a user message with
+	// no assistant message after it; flag it so the UI notes the interruption rather
+	// than showing a bare, unanswered bubble.
+	const built = messages.value;
+	for (let i = 0; i < built.length; i++) {
+		if (built[i].role === "user" && built[i + 1]?.role !== "assistant")
+			built[i].interrupted = true;
+	}
+
 	requestScroll();
 	await restorePausedRun(name);
 }


### PR DESCRIPTION
When a user refreshes or navigates away mid-stream, the WSGI `GeneratorExit` path in `stream_with_persistence` does not fire reliably (confirmed in dev and in production). The run stays in `Running` indefinitely, blocking the next turn with "session already has a run in progress" until the 5-minute stale timeout triggers on the next send.

## What changed

**Backend** — new `recover_session(session)` whitelisted endpoint in `flow/api/api.py`. Ownership-checked via `_assert_session_owner`. Fails all `Running` runs on the session immediately and returns `{"recovered": N}`. The existing `_assert_not_blocked` stale-timeout remains as a last-resort fallback.

**Frontend (store.js)** — `switchSession` calls `recoverSession` (fire-and-forget, `.catch(() => {})`) before loading the session doc. Any stuck run is cleared before the user can type. After rebuilding the transcript, flags user messages with no assistant reply after them as `interrupted = true` — these are turns whose streams died before persisting a response.

**Frontend (MessageList.vue)** — renders a muted "Response interrupted" notice (alert-circle icon) below each flagged user bubble instead of leaving a bare unanswered message.

## Why load-time recovery is correct

A `Running` run on session load means the stream was owned by a prior page connection that no longer exists. There is no scenario where a legitimate in-flight run is present when a different page loads the session — streams are tied to their HTTP connection.

Verified on session `j93uj6g1ge`: run `i675ldft11` recovered from `Running` → `Failed` immediately on `switchSession`.