### PR TITLE
fix: remove agent dot and reduce dropdown item font size

### DIFF
--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -172,7 +172,6 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 							:title="__('Agent')"
 							@click="toggle"
 						>
-							<span class="h-1.5 w-1.5 rounded-full bg-surface-green-3"></span>
 							<span class="font-medium text-ink-gray-8">{{
 								agentLabel(selectedAgent)
 							}}</span>

--- a/frontend/src/components/PanelDropdown.vue
+++ b/frontend/src/components/PanelDropdown.vue
@@ -37,7 +37,7 @@ function select(item) {
 				<button
 					v-for="item in items"
 					:key="item.value ?? '__default'"
-					class="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-ink-gray-8 hover:bg-surface-gray-2"
+					class="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-xs text-ink-gray-8 hover:bg-surface-gray-2"
 					:class="{ 'bg-surface-gray-2': item.value === modelValue }"
 					@click="select(item)"
 				>


### PR DESCRIPTION
Removes the green status dot to the left of the agent name in the composer footer, and reduces the font size of agent/model dropdown items from `text-sm` to `text-xs`.