### PR TITLE
fix: isolate lancedb store path during tests

### DIFF
--- a/flow/knowledge/store.py
+++ b/flow/knowledge/store.py
@@ -25,7 +25,8 @@ MAX_SEARCH_LIMIT = 100
 
 
 def db_path() -> str:
-	return frappe.get_site_path("private", "files", "lancedb")
+	name = "lancedb_test" if frappe.flags.in_test else "lancedb"
+	return frappe.get_site_path("private", "files", name)
 
 
 def _connect():


### PR DESCRIPTION
Tests called `drop_table()` in setUp/tearDown against the live site path, permanently destroying the real `chunks` table while MariaDB chunks survived the test rollback.

Fix: `db_path()` now returns `lancedb_test` when `frappe.flags.in_test`. Covers both stores since `attachment_store` reuses `_connect()` from `store.py`.