### PR TITLE
fix: return native promise from knowledge source action buttons

### DIFF
--- a/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.js
+++ b/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.js
@@ -7,21 +7,17 @@ frappe.ui.form.on("AI Knowledge Source", {
 			return;
 		}
 
-		frm.add_custom_button(__("Resync"), () =>
-			frm.call("resync").then(() => {
-				frappe.show_alert({ message: __("Resync started"), indicator: "blue" });
-				frm.reload_doc();
-			})
-		);
+		frm.add_custom_button(__("Resync"), async () => {
+			await frm.call("resync");
+			frappe.show_alert({ message: __("Resync started"), indicator: "blue" });
+			frm.reload_doc();
+		});
 
 		if (frm.doc.source_type === "DocType") {
-			frm.add_custom_button(__("Reconcile"), () =>
-				frm
-					.call("reconcile")
-					.then(() =>
-						frappe.show_alert({ message: __("Reconcile started"), indicator: "blue" })
-					)
-			);
+			frm.add_custom_button(__("Reconcile"), async () => {
+				await frm.call("reconcile");
+				frappe.show_alert({ message: __("Reconcile started"), indicator: "blue" });
+			});
 		}
 	},
 });


### PR DESCRIPTION
Resync/Reconcile handlers returned a jQuery promise. Frappe's `page.js` calls `.finally()` to re-enable the button, but jQuery promises expose `.always()` not `.finally()`, causing `TypeError: response.finally is not a function`.

Made both handlers `async` so they return native Promises which have `.finally()`.