### PR TITLE
feat: allow all users to access the AI assistant

### DIFF
--- a/flow/ai/doctype/ai_agent/ai_agent.json
+++ b/flow/ai/doctype/ai_agent/ai_agent.json
@@ -120,6 +120,10 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All"
   }
  ],
  "row_format": "Dynamic",

--- a/flow/ai/doctype/ai_model/ai_model.json
+++ b/flow/ai/doctype/ai_model/ai_model.json
@@ -100,6 +100,10 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All"
   }
  ],
  "row_format": "Dynamic",

--- a/flow/ai/doctype/ai_run/ai_run.json
+++ b/flow/ai/doctype/ai_run/ai_run.json
@@ -198,6 +198,11 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "if_owner": 1,
+   "read": 1,
+   "role": "All"
   }
  ],
  "row_format": "Dynamic",

--- a/flow/ai/doctype/ai_session/ai_session.json
+++ b/flow/ai/doctype/ai_session/ai_session.json
@@ -85,6 +85,14 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "if_owner": 1,
+   "read": 1,
+   "role": "All",
+   "write": 1
   }
  ],
  "row_format": "Dynamic",


### PR DESCRIPTION
## Summary
Grant the `All` role the minimum permissions needed for any logged-in user to use the chat assistant end-to-end.

| Doctype | Permissions | `if_owner` |
|---|---|---|
| AI Session | read, write, create, delete | Yes |
| AI Run | read | Yes |
| AI Agent | read | No |
| AI Model | read | No |

`if_owner` on AI Session and AI Run means users can only see and interact with their own sessions — `get_list` is automatically scoped to `owner = current_user` at the DB level.

AI Agent and AI Model are shared system resources (read-only for normal users).

All internal writes (session/run creation, message persistence) already use `ignore_permissions=True` and require no additional grants.