### PR TITLE
refactor: Python as single source of truth for supported file types

### DIFF
--- a/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.js
+++ b/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.js
@@ -28,41 +28,14 @@ frappe.ui.form.on("AI Knowledge Source", {
 	},
 });
 
-// Formats the ingest pipeline can extract. Keep in sync with FILE_EXTENSIONS in
-// flow/knowledge/extract.py.
-const SUPPORTED_FILE_TYPES = [
-	".txt",
-	".text",
-	".md",
-	".markdown",
-	".csv",
-	".tsv",
-	".log",
-	".rst",
-	".json",
-	".yaml",
-	".yml",
-	".pdf",
-	".xlsx",
-	".docx",
-	".html",
-	".htm",
-	".png",
-	".jpg",
-	".jpeg",
-	".webp",
-	".bmp",
-	".tiff",
-	".tif",
-	".gif",
-];
-
 // Cap the File picker to the formats the ingest pipeline can actually extract.
+// Types come from frappe.boot
 function apply_file_restrictions(frm) {
 	if (frm.doc.source_type !== "File") {
 		return;
 	}
+	const types = (frappe.boot.flow_supported_file_types || []).map((ext) => `.${ext}`);
 	frm.fields_dict.file.df.options = {
-		restrictions: { allowed_file_types: SUPPORTED_FILE_TYPES },
+		restrictions: { allowed_file_types: types },
 	};
 }

--- a/flow/boot.py
+++ b/flow/boot.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+from flow.knowledge.extract import FILE_EXTENSIONS
+
+
+def boot_session(bootinfo):
+	# Single source of truth for file types the ingest pipeline can extract
+	bootinfo.flow_supported_file_types = sorted(FILE_EXTENSIONS)

--- a/flow/hooks.py
+++ b/flow/hooks.py
@@ -56,3 +56,5 @@ scheduler_events = {
 }
 
 after_migrate = ["flow.assistant.sync_builtin_assistant"]
+
+extend_bootinfo = "flow.boot.boot_session"

--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -27,8 +27,10 @@ const {
 	removeAttachment,
 } = useStore();
 
-const ACCEPT =
-	".pdf,.xlsx,.docx,.html,.htm,.txt,.text,.md,.markdown,.csv,.tsv,.log,.rst,.json,.yaml,.yml";
+// Backend (flow/boot.py) is the single source of truth for supported file types.
+const ACCEPT = computed(() =>
+	(frappe.boot.flow_supported_file_types || []).map((ext) => `.${ext}`).join(",")
+);
 
 const text = ref("");
 const el = ref(null);


### PR DESCRIPTION
## Summary
`FILE_EXTENSIONS` in `extract.py` is now the only place supported file types are defined. Both the AI Knowledge Source file picker (desk) and the chat composer (SPA) read from `frappe.boot` instead of maintaining their own copies.

- `flow/boot.py` — new `extend_bootinfo` hook that puts `flow_supported_file_types` on `frappe.boot`
- `ai_knowledge_source.js` — drops hardcoded list, reads from `frappe.boot.flow_supported_file_types`
- `Composer.vue` — drops hardcoded `ACCEPT` string, computed from the same boot value