### PR TITLE
feat: delete attached files when clearing old AI sessions

### DIFF
--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -87,6 +87,7 @@ class AISession(Document):
 		for batch in frappe.utils.create_batch(sessions, 100):
 			frappe.db.delete("AI Run", {"session": ["in", batch]})
 			frappe.db.delete("AI Session Message", {"parent": ["in", batch]})
+			_delete_attachment_files(batch)
 			frappe.db.delete("AI Session Attachment", {"parent": ["in", batch]})
 			frappe.db.delete("AI Session", {"name": ["in", batch]})
 			_purge_attachment_chunks(batch)
@@ -357,6 +358,18 @@ class AISession(Document):
 			_("This session already has a run in progress."),
 			title=_("Run In Progress"),
 		)
+
+
+def _delete_attachment_files(sessions: list[str]) -> None:
+	"""Delete the uploaded File docs attached to these sessions. Per-doc (not bulk SQL)
+	so File.on_trash runs to remove the on-disk content, and best-effort so one failure
+	never aborts the purge."""
+	files = frappe.get_all("AI Session Attachment", filters={"parent": ["in", sessions]}, pluck="file")
+	for file in set(filter(None, files)):
+		try:
+			frappe.delete_doc("File", file, ignore_permissions=True, force=True, delete_permanently=True)
+		except Exception:
+			frappe.log_error(title="Chat attachment file cleanup failed")
 
 
 def _purge_attachment_chunks(session: str | list[str]) -> None:

--- a/flow/ai/doctype/ai_session/test_ai_session.py
+++ b/flow/ai/doctype/ai_session/test_ai_session.py
@@ -82,7 +82,7 @@ class TestClearOldLogs(IntegrationTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
-	def _session_with_run(self, *, age_days: int) -> str:
+	def _session_with_run(self, *, age_days: int) -> tuple[str, str, str]:
 		f = frappe.get_doc({"doctype": "File", "file_name": "f.txt", "content": "x", "is_private": 1}).insert(
 			ignore_permissions=True
 		)
@@ -95,10 +95,10 @@ class TestClearOldLogs(IntegrationTestCase):
 		).insert(ignore_permissions=True)
 		old = frappe.utils.add_days(frappe.utils.now(), -age_days)
 		frappe.db.set_value("AI Session", session.name, "modified", old, update_modified=False)
-		return session.name, run.name
+		return session.name, run.name, f.name
 
 	def test_old_session_and_linked_run_and_messages_are_purged(self):
-		old_session, old_run = self._session_with_run(age_days=100)
+		old_session, old_run, old_file = self._session_with_run(age_days=100)
 
 		AISession.clear_old_logs(days=30)
 
@@ -106,14 +106,16 @@ class TestClearOldLogs(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("AI Run", old_run))
 		self.assertEqual(frappe.db.count("AI Session Message", {"parent": old_session}), 0)
 		self.assertEqual(frappe.db.count("AI Session Attachment", {"parent": old_session}), 0)
+		self.assertFalse(frappe.db.exists("File", old_file))
 
 	def test_recent_session_is_kept(self):
-		recent_session, recent_run = self._session_with_run(age_days=1)
+		recent_session, recent_run, recent_file = self._session_with_run(age_days=1)
 
 		AISession.clear_old_logs(days=30)
 
 		self.assertTrue(frappe.db.exists("AI Session", recent_session))
 		self.assertTrue(frappe.db.exists("AI Run", recent_run))
+		self.assertTrue(frappe.db.exists("File", recent_file))
 
 
 class TestDeriveTitle(IntegrationTestCase):


### PR DESCRIPTION
Old-session cleanup (`AISession.clear_old_logs`) deleted sessions, runs, transcript rows, and attachment rows — but left the uploaded `File` docs (and their on-disk content) orphaned.

Now each purged session's attached files are deleted per-doc so `File.on_trash` removes the disk content, hard-purged (`delete_permanently`) to match the surrounding bulk deletes, and best-effort so one failure never aborts the sweep.