### PR TITLE
feat: per-source chunk size/overlap with confirm-rebuild dialog

### DIFF
--- a/flow/ai/doctype/ai_agent/test_ai_agent.py
+++ b/flow/ai/doctype/ai_agent/test_ai_agent.py
@@ -125,6 +125,8 @@ class TestAIAgentKnowledgeSearch(IntegrationTestCase):
 	def setUp(self):
 		sync_builtin_tools()
 		self.model_doc = frappe.get_doc(_model()).insert()
+		frappe.db.set_single_value("AI Knowledge Settings", "embedding_model", self.model_doc.name)
+		frappe.clear_document_cache("AI Knowledge Settings", "AI Knowledge Settings")
 		self.kb = frappe.get_doc({"doctype": "AI Knowledge Base", "title": "Agent KB"}).insert()
 
 	def tearDown(self):

--- a/flow/ai/doctype/ai_knowledge_base/ai_knowledge_base.py
+++ b/flow/ai/doctype/ai_knowledge_base/ai_knowledge_base.py
@@ -18,4 +18,8 @@ class AIKnowledgeBase(Document):
 		title: DF.Data
 	# end: auto-generated types
 
-	pass
+	def validate(self):
+		if self.is_new():
+			from flow.ai.doctype.ai_knowledge_settings.ai_knowledge_settings import require_embedding_model
+
+			require_embedding_model()

--- a/flow/ai/doctype/ai_knowledge_settings/ai_knowledge_settings.py
+++ b/flow/ai/doctype/ai_knowledge_settings/ai_knowledge_settings.py
@@ -64,3 +64,13 @@ class AIKnowledgeSettings(Document):
 		from flow.knowledge.embedder import probe_dimension
 
 		self.embedding_dimension = probe_dimension(self.embedding_model)
+
+
+def require_embedding_model():
+	"""Knowledge ingestion needs an embedding model; block creating knowledge docs until one is set."""
+	settings = frappe.get_cached_doc("AI Knowledge Settings")
+	if not settings.embedding_model:
+		frappe.throw(
+			_("Set an embedding model in AI Knowledge Settings before adding knowledge bases or sources."),
+			title=_("AI Knowledge Settings Required"),
+		)

--- a/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.js
+++ b/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.js
@@ -9,6 +9,11 @@ frappe.ui.form.on("AI Knowledge Source", {
 			return;
 		}
 
+		frm.__chunking_baseline = {
+			chunk_size: frm.doc.chunk_size,
+			chunk_overlap: frm.doc.chunk_overlap,
+		};
+
 		frm.add_custom_button(__("Resync"), async () => {
 			await frm.call("resync");
 			frappe.show_alert({ message: __("Resync started"), indicator: "blue" });
@@ -21,6 +26,35 @@ frappe.ui.form.on("AI Knowledge Source", {
 				frappe.show_alert({ message: __("Reconcile started"), indicator: "blue" });
 			});
 		}
+	},
+
+	after_save(frm) {
+		const baseline = frm.__chunking_baseline;
+		if (!baseline || !frm.doc.chunk_count) {
+			return;
+		}
+		const changed =
+			baseline.chunk_size !== frm.doc.chunk_size ||
+			baseline.chunk_overlap !== frm.doc.chunk_overlap;
+		if (!changed) {
+			return;
+		}
+		frm.__chunking_baseline = {
+			chunk_size: frm.doc.chunk_size,
+			chunk_overlap: frm.doc.chunk_overlap,
+		};
+		frappe.confirm(
+			__(
+				"Chunk settings changed. The {0} existing chunks for this source will be deleted and rebuilt with the new settings. Re-process now?",
+				[frm.doc.chunk_count]
+			),
+			() => {
+				frm.call("resync", { rebuild: 1 }).then(() => {
+					frappe.show_alert({ message: __("Re-ingestion started"), indicator: "blue" });
+					frm.reload_doc();
+				});
+			}
+		);
 	},
 
 	source_type(frm) {

--- a/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.json
+++ b/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.json
@@ -17,6 +17,10 @@
   "filters",
   "content_fields",
   "auto_sync",
+  "section_break_chunking",
+  "chunk_size",
+  "column_break_chunking",
+  "chunk_overlap",
   "section_break_status",
   "status",
   "column_break_status",
@@ -114,6 +118,32 @@
    "fieldname": "auto_sync",
    "fieldtype": "Check",
    "label": "Auto Sync"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_chunking",
+   "fieldtype": "Section Break",
+   "label": "Chunking"
+  },
+  {
+   "default": "0",
+   "description": "Characters per chunk for this source. Leave 0 to inherit the global default from AI Knowledge Settings.",
+   "fieldname": "chunk_size",
+   "fieldtype": "Int",
+   "label": "Chunk Size",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "column_break_chunking",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Characters shared between consecutive chunks. Leave 0 to inherit the global default.",
+   "fieldname": "chunk_overlap",
+   "fieldtype": "Int",
+   "label": "Chunk Overlap",
+   "non_negative": 1
   },
   {
    "fieldname": "section_break_status",

--- a/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.py
+++ b/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.py
@@ -73,32 +73,19 @@ class AIKnowledgeSource(Document):
 
 		enqueue_ingestion(self.name)
 
-	def on_update(self):
-		"""Chunk size/overlap changed → existing chunks are stale. Rebuild from scratch
-		(incremental sweep is hash-gated and would skip unchanged rows)."""
-		previous = self.get_doc_before_save()
-		if previous is None:
-			return
-		if (previous.chunk_size, previous.chunk_overlap) == (self.chunk_size, self.chunk_overlap):
-			return
-		if not self.chunk_count:
-			return
-		from flow.knowledge.ingest import enqueue_ingestion
-
-		self.db_set("status", "Pending", update_modified=False)
-		enqueue_ingestion(self.name, rebuild=True)
-
 	def on_trash(self):
 		from flow.knowledge.ingest import purge_source
 
 		purge_source(self.name)
 
 	@frappe.whitelist()
-	def resync(self):
+	def resync(self, rebuild: bool = False):
+		"""rebuild forces a full re-chunk; used when chunk settings change and the
+		existing chunks are stale."""
 		from flow.knowledge.ingest import enqueue_ingestion
 
 		self.db_set("status", "Pending", update_modified=False)
-		enqueue_ingestion(self.name)
+		enqueue_ingestion(self.name, rebuild=bool(rebuild))
 
 	@frappe.whitelist()
 	def reconcile(self):

--- a/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.py
+++ b/flow/ai/doctype/ai_knowledge_source/ai_knowledge_source.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint
 
 REQUIRED_INPUT = {
 	"Text": "content",
@@ -24,6 +25,8 @@ class AIKnowledgeSource(Document):
 
 		auto_sync: DF.Check
 		chunk_count: DF.Int
+		chunk_overlap: DF.Int
+		chunk_size: DF.Int
 		content: DF.LongText | None
 		content_fields: DF.SmallText | None
 		error_log: DF.LongText | None
@@ -39,6 +42,10 @@ class AIKnowledgeSource(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		if self.is_new():
+			from flow.ai.doctype.ai_knowledge_settings.ai_knowledge_settings import require_embedding_model
+
+			require_embedding_model()
 		fieldname = REQUIRED_INPUT.get(self.source_type)
 		if fieldname and not self.get(fieldname):
 			frappe.throw(
@@ -52,6 +59,12 @@ class AIKnowledgeSource(Document):
 				_("Content Fields is required for a DocType source."),
 				frappe.MandatoryError,
 			)
+		self._validate_chunking()
+
+	def _validate_chunking(self):
+		"""0 inherits the global default. Only validate values set on the source itself."""
+		if self.chunk_size and self.chunk_overlap and cint(self.chunk_overlap) >= cint(self.chunk_size):
+			frappe.throw(_("Chunk Overlap must be smaller than Chunk Size."), title=_("Invalid Chunking"))
 
 	def after_insert(self):
 		if self.flags.skip_auto_ingest:
@@ -59,6 +72,21 @@ class AIKnowledgeSource(Document):
 		from flow.knowledge.ingest import enqueue_ingestion
 
 		enqueue_ingestion(self.name)
+
+	def on_update(self):
+		"""Chunk size/overlap changed → existing chunks are stale. Rebuild from scratch
+		(incremental sweep is hash-gated and would skip unchanged rows)."""
+		previous = self.get_doc_before_save()
+		if previous is None:
+			return
+		if (previous.chunk_size, previous.chunk_overlap) == (self.chunk_size, self.chunk_overlap):
+			return
+		if not self.chunk_count:
+			return
+		from flow.knowledge.ingest import enqueue_ingestion
+
+		self.db_set("status", "Pending", update_modified=False)
+		enqueue_ingestion(self.name, rebuild=True)
 
 	def on_trash(self):
 		from flow.knowledge.ingest import purge_source

--- a/flow/knowledge/ingest.py
+++ b/flow/knowledge/ingest.py
@@ -24,12 +24,13 @@ CHUNK_DOCTYPE = "AI Knowledge Chunk"
 BATCH = 500
 
 
-def enqueue_ingestion(source: str) -> None:
+def enqueue_ingestion(source: str, rebuild: bool = False) -> None:
 	frappe.enqueue(
 		"flow.knowledge.ingest.ingest_source",
 		queue="long",
 		enqueue_after_commit=True,
 		source=source,
+		rebuild=rebuild,
 	)
 
 
@@ -53,8 +54,12 @@ def enqueue_reconciliation(source: str) -> None:
 	)
 
 
-def ingest_source(source: str) -> None:
-	"""Worker: bring a source's chunks in both stores up to date."""
+def ingest_source(source: str, rebuild: bool = False) -> None:
+	"""Worker: bring a source's chunks in both stores up to date.
+
+	rebuild forces a full re-chunk of a DocType source (purge + reset watermark) so
+	new chunk settings apply to rows whose content is otherwise unchanged. Single-doc
+	sources rebuild on every run regardless."""
 	doc = frappe.get_doc("AI Knowledge Source", source)
 	doc.db_set("status", "Processing", update_modified=False)
 	frappe.db.commit()
@@ -62,6 +67,9 @@ def ingest_source(source: str) -> None:
 	try:
 		settings = frappe.get_cached_doc("AI Knowledge Settings")
 		if doc.source_type == "DocType":
+			if rebuild:
+				purge_source(doc.name)
+				doc.db_set("last_synced_at", None, update_modified=False)
 			_sync_doctype(doc, settings)
 		else:
 			_rebuild_single(doc, settings)
@@ -96,13 +104,10 @@ def _rebuild_single(doc, settings) -> None:
 	from flow.knowledge.embedder import embed_texts
 	from flow.knowledge.extract import extract
 
+	size, overlap = _chunk_params(doc, settings)
 	pieces = []
 	for extracted in extract(doc):
-		pieces.extend(
-			chunk_text(
-				extracted.text, chunk_size=cint(settings.chunk_size), overlap=cint(settings.chunk_overlap)
-			)
-		)
+		pieces.extend(chunk_text(extracted.text, chunk_size=size, overlap=overlap))
 
 	purge_source(doc.name)
 	if not pieces:
@@ -196,7 +201,7 @@ def _upsert_page(doc, settings, meta, fields, page, matched_refs, *, track_exits
 			continue
 		if existing["ids"]:
 			stale.append(name)
-		pieces = _chunk(text, settings)
+		pieces = _chunk(text, doc, settings)
 		if pieces:
 			to_embed.append((name, new_hash, pieces))
 
@@ -323,10 +328,18 @@ def _existing_names(doctype: str, names: set[str]) -> set[str]:
 	return found
 
 
-def _chunk(text, settings) -> list[str]:
+def _chunk(text, doc, settings) -> list[str]:
 	from flow.knowledge.chunker import chunk_text
 
-	return chunk_text(text, chunk_size=cint(settings.chunk_size), overlap=cint(settings.chunk_overlap))
+	size, overlap = _chunk_params(doc, settings)
+	return chunk_text(text, chunk_size=size, overlap=overlap)
+
+
+def _chunk_params(doc, settings) -> tuple[int, int]:
+	"""Per-source chunk size/overlap, each falling back to the global default when 0."""
+	size = cint(doc.chunk_size) or cint(settings.chunk_size)
+	overlap = cint(doc.chunk_overlap) or cint(settings.chunk_overlap)
+	return size, overlap
 
 
 def _content_hash(text: str) -> str:

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -1101,6 +1101,9 @@ class TestKnowledgeBuilder(IntegrationTestCase):
 
 
 class TestAgentKnowledge(IntegrationTestCase):
+	def setUp(self):
+		_set_settings(embedding_model=_make_model().name)
+
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -689,6 +689,45 @@ class TestIngest(IntegrationTestCase):
 			).insert()
 		mock.assert_called_once_with(source.name)
 
+	def test_per_source_chunk_size_overrides_global(self):
+		content = "Wifi keeps dropping on the office network every afternoon. " * 4
+		default_source = self._make_source(content=content, title="Default Chunking")
+		self._ingest(default_source.name)
+		big_source = self._make_source(content=content, title="Big Chunking", chunk_size=400)
+		self._ingest(big_source.name)
+		self.assertGreater(len(self._chunks(default_source.name)), len(self._chunks(big_source.name)))
+
+	def test_per_source_overlap_must_be_smaller_than_size(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "Chunk Overlap"):
+			self._make_source(content="x", chunk_size=100, chunk_overlap=100)
+
+	def test_knowledge_base_requires_embedding_model(self):
+		_set_settings(embedding_model="")
+		with self.assertRaisesRegex(frappe.ValidationError, "AI Knowledge Settings"):
+			frappe.get_doc({"doctype": "AI Knowledge Base", "title": "No Model KB"}).insert()
+
+	def test_source_requires_embedding_model(self):
+		_set_settings(embedding_model="")
+		with self.assertRaisesRegex(frappe.ValidationError, "AI Knowledge Settings"):
+			self._make_source(content="needs a model")
+
+	def test_chunk_param_change_rebuilds_when_chunks_exist(self):
+		source = self._make_source(content="Reset your password from the account settings page. " * 4)
+		self._ingest(source.name)
+		source.reload()
+		self.assertGreater(source.chunk_count, 0)
+		with patch("flow.knowledge.ingest.enqueue_ingestion") as mock:
+			source.chunk_size = 400
+			source.save()
+		mock.assert_called_once_with(source.name, rebuild=True)
+
+	def test_chunk_param_change_skips_rebuild_without_chunks(self):
+		source = self._make_source(content="never ingested")
+		with patch("flow.knowledge.ingest.enqueue_ingestion") as mock:
+			source.chunk_size = 400
+			source.save()
+		mock.assert_not_called()
+
 
 class TestDoctypeSync(IntegrationTestCase):
 	def setUp(self):

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -711,22 +711,11 @@ class TestIngest(IntegrationTestCase):
 		with self.assertRaisesRegex(frappe.ValidationError, "AI Knowledge Settings"):
 			self._make_source(content="needs a model")
 
-	def test_chunk_param_change_rebuilds_when_chunks_exist(self):
+	def test_resync_rebuild_enqueues_full_rebuild(self):
 		source = self._make_source(content="Reset your password from the account settings page. " * 4)
-		self._ingest(source.name)
-		source.reload()
-		self.assertGreater(source.chunk_count, 0)
 		with patch("flow.knowledge.ingest.enqueue_ingestion") as mock:
-			source.chunk_size = 400
-			source.save()
+			source.resync(rebuild=True)
 		mock.assert_called_once_with(source.name, rebuild=True)
-
-	def test_chunk_param_change_skips_rebuild_without_chunks(self):
-		source = self._make_source(content="never ingested")
-		with patch("flow.knowledge.ingest.enqueue_ingestion") as mock:
-			source.chunk_size = 400
-			source.save()
-		mock.assert_not_called()
 
 
 class TestDoctypeSync(IntegrationTestCase):


### PR DESCRIPTION
Adds per-source `chunk_size` and `chunk_overlap` fields to AI Knowledge Source (0 = inherit global). When either value changes on a source that already has chunks, the client shows a confirm dialog before triggering a full rebuild.

**Changes**
- `ai_knowledge_source.json` — collapsible Chunking section with two Int fields (default 0)
- `ingest.py` — `_chunk_params(doc, settings)` resolves per-source → global fallback; `ingest_source` + `enqueue_ingestion` accept `rebuild` flag; DocType rebuild purges chunks and resets watermark
- `ai_knowledge_source.py` — `validate` checks embedding model on creation and validates source-own overlap < size; `on_update` silent rebuild removed; `resync` accepts `rebuild: bool`
- `ai_knowledge_source.js` — snapshots chunk params on `refresh`; `after_save` shows `frappe.confirm` if params changed and chunks exist, calls `resync(rebuild=1)` on accept
- `ai_knowledge_base.py` / `ai_knowledge_settings.py` — throw if no embedding model is configured when creating a knowledge base or source