### PR TITLE
AI panel tweaks: Flow rename, session search, composer fixes

### DIFF
--- a/flow/assistant/assistant.py
+++ b/flow/assistant/assistant.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import frappe
 
-ASSISTANT_AGENT_TITLE = "Assistant"
+ASSISTANT_AGENT_TITLE = "Flow"
 ASSISTANT_MAX_ITERATIONS = 40
 
 ASSISTANT_INSTRUCTIONS = (

--- a/flow/tests/test_ai_api.py
+++ b/flow/tests/test_ai_api.py
@@ -352,11 +352,12 @@ class TestStartRunSessions(IntegrationTestCase):
 
 	def test_explicit_session_id_reuses_it(self):
 		from flow.assistant import sync_builtin_assistant
+		from flow.assistant.assistant import ASSISTANT_AGENT_TITLE
 
 		sync_builtin_assistant(model=self.model_doc.name)
-		session = frappe.get_doc({"doctype": "AI Session", "agent": "Assistant", "title": "carried"}).insert(
-			ignore_permissions=True
-		)
+		session = frappe.get_doc(
+			{"doctype": "AI Session", "agent": ASSISTANT_AGENT_TITLE, "title": "carried"}
+		).insert(ignore_permissions=True)
 
 		with patch.object(Model, "chat", return_value=_final()):
 			result = start_run("hi", session=session.name)

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -17,9 +17,12 @@ export const loadHistory = () =>
 		limit: 15,
 	});
 
+// Escape LIKE wildcards so a literal % or _ matches itself, not "anything".
+const escapeLike = (s) => s.replace(/[\\%_]/g, "\\$&");
+
 export const searchSessions = (query) =>
 	getList("AI Session", {
-		filters: { owner: frappe.session.user, title: ["like", `%${query}%`] },
+		filters: { owner: frappe.session.user, title: ["like", `%${escapeLike(query)}%`] },
 		fields: ["name", "title", "creation"],
 		order_by: "creation desc",
 		limit: 20,

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -17,6 +17,14 @@ export const loadHistory = () =>
 		limit: 15,
 	});
 
+export const searchSessions = (query) =>
+	getList("AI Session", {
+		filters: { owner: frappe.session.user, title: ["like", `%${query}%`] },
+		fields: ["name", "title", "creation"],
+		order_by: "creation desc",
+		limit: 20,
+	});
+
 export const getSession = (name) =>
 	frappe.xcall("frappe.client.get", { doctype: "AI Session", name });
 

--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -61,7 +61,7 @@ function submit() {
 	if (!canSend.value) return;
 	send(text.value);
 	text.value = "";
-	resize();
+	nextTick(resize);
 }
 
 function pickFiles() {

--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -35,7 +35,7 @@ defineProps({
 				>
 					{{
 						__(
-							"Enable an AI Agent (an Assistant is created automatically once a model exists)."
+							"Enable an AI Agent (Flow Agent is created automatically once a model exists)."
 						)
 					}}
 				</li>
@@ -52,7 +52,7 @@ defineProps({
 		</template>
 
 		<template v-else>
-			<div class="text-lg font-semibold text-ink-gray-9">{{ __("AI Assistant") }}</div>
+			<div class="text-lg font-semibold text-ink-gray-9">{{ __("Flow") }}</div>
 			<div class="max-w-[240px] text-xs leading-relaxed">
 				{{ __("Ask about your data, draft records, or run a task.") }}
 			</div>

--- a/frontend/src/components/PanelDropdown.vue
+++ b/frontend/src/components/PanelDropdown.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from "vue";
+import { ref, nextTick, watch } from "vue";
 import { FeatherIcon } from "@/lib/ui";
 
 // Inline dropdown (rendered within #flow-root, never teleported) so its styles
@@ -13,6 +13,8 @@ const props = defineProps({
 const emit = defineEmits(["update:modelValue"]);
 
 const open = ref(false);
+const menu = ref(null);
+const shift = ref(0);
 
 function toggle() {
 	if (props.disabled) return;
@@ -22,6 +24,22 @@ function select(item) {
 	emit("update:modelValue", item.value);
 	open.value = false;
 }
+
+// Keep the menu inside the panel: open aligned to the trigger, then shift it
+// horizontally if either edge would spill past #flow-root. Measured once per
+// open (a click) — no resize/scroll listeners.
+watch(open, async (v) => {
+	shift.value = 0;
+	if (!v) return;
+	await nextTick();
+	const panel = document.getElementById("flow-root");
+	if (!menu.value || !panel) return;
+	const m = menu.value.getBoundingClientRect();
+	const p = panel.getBoundingClientRect();
+	const margin = 8;
+	if (m.right > p.right - margin) shift.value = p.right - margin - m.right;
+	else if (m.left < p.left + margin) shift.value = p.left + margin - m.left;
+});
 </script>
 
 <template>
@@ -31,8 +49,10 @@ function select(item) {
 		<template v-if="open">
 			<div class="fixed inset-0 z-40" @click="open = false"></div>
 			<div
+				ref="menu"
 				class="absolute bottom-[calc(100%+8px)] z-50 max-h-80 w-max min-w-[12rem] max-w-[15rem] overflow-y-auto rounded-lg border border-outline-gray-2 bg-surface-white p-1.5 shadow-2xl space-y-0.5"
 				:class="align === 'right' ? 'right-0' : 'left-0'"
+				:style="shift ? { transform: `translateX(${shift}px)` } : null"
 			>
 				<button
 					v-for="item in items"

--- a/frontend/src/components/PanelHeader.vue
+++ b/frontend/src/components/PanelHeader.vue
@@ -13,7 +13,7 @@ const { recentSessions, switchSession, newChat, fullscreen } = useStore();
 <template>
 	<header class="flex items-center gap-1.5 border-b border-outline-gray-1 px-3 py-2">
 		<BrandMark :size="18" />
-		<span class="text-sm font-medium text-ink-gray-9">{{ __("AI Assistant") }}</span>
+		<span class="text-sm font-medium text-ink-gray-9">{{ __("Flow") }}</span>
 		<span class="flex-1"></span>
 
 		<SessionsMenu :sessions="recentSessions" @select="switchSession" />

--- a/frontend/src/components/SessionsMenu.vue
+++ b/frontend/src/components/SessionsMenu.vue
@@ -13,9 +13,11 @@ const results = ref([]);
 const searching = ref(false);
 
 let debounce;
+let searchSeq = 0;
 watch(query, (q) => {
 	clearTimeout(debounce);
 	q = q.trim();
+	const seq = ++searchSeq; // ignore responses from superseded queries
 	if (!q) {
 		results.value = [];
 		searching.value = false;
@@ -24,9 +26,10 @@ watch(query, (q) => {
 	searching.value = true;
 	debounce = setTimeout(async () => {
 		try {
-			results.value = await searchSessions(q);
+			const found = await searchSessions(q);
+			if (seq === searchSeq) results.value = found;
 		} finally {
-			searching.value = false;
+			if (seq === searchSeq) searching.value = false;
 		}
 	}, 250);
 });

--- a/frontend/src/components/SessionsMenu.vue
+++ b/frontend/src/components/SessionsMenu.vue
@@ -1,12 +1,42 @@
 <script setup>
-import { ref } from "vue";
+import { ref, computed, watch } from "vue";
 import { Button, FeatherIcon } from "@/lib/ui";
 import { __ } from "@/lib/translate";
+import { searchSessions } from "@/api/client";
 
-defineProps({ sessions: { type: Array, default: () => [] } });
+const props = defineProps({ sessions: { type: Array, default: () => [] } });
 const emit = defineEmits(["select"]);
 
 const open = ref(false);
+const query = ref("");
+const results = ref([]);
+const searching = ref(false);
+
+let debounce;
+watch(query, (q) => {
+	clearTimeout(debounce);
+	q = q.trim();
+	if (!q) {
+		results.value = [];
+		searching.value = false;
+		return;
+	}
+	searching.value = true;
+	debounce = setTimeout(async () => {
+		try {
+			results.value = await searchSessions(q);
+		} finally {
+			searching.value = false;
+		}
+	}, 250);
+});
+
+watch(open, (v) => {
+	if (!v) query.value = "";
+});
+
+// Server results while searching, otherwise the recent list passed in.
+const list = computed(() => (query.value.trim() ? results.value : props.sessions));
 
 function choose(name) {
 	open.value = false;
@@ -32,12 +62,15 @@ function timeAgo(ds) {
 			<div
 				class="absolute right-0 z-50 mt-1.5 flex w-72 flex-col overflow-hidden rounded-lg border border-outline-gray-2 bg-surface-white shadow-2xl"
 			>
-				<div class="flex items-center border-b border-outline-gray-1 py-2 pl-3 pr-2">
-					<span class="flex-1 text-xs font-medium text-ink-gray-7">
-						{{ __("Recent sessions") }}
-					</span>
+				<div class="flex items-center gap-2 border-b border-outline-gray-1 py-1 pl-3 pr-2">
+					<FeatherIcon name="search" class="h-3.5 w-3.5 shrink-0 text-ink-gray-5" />
+					<input
+						v-model="query"
+						:placeholder="__('Search sessions…')"
+						class="min-w-0 flex-1 border-0 bg-transparent text-sm text-ink-gray-8 outline-none focus:shadow-none focus:outline-none focus:ring-0 placeholder:text-ink-gray-4"
+					/>
 					<button
-						class="flex h-5 w-5 items-center justify-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
+						class="flex h-5 w-5 shrink-0 items-center justify-center rounded text-ink-gray-5 hover:bg-surface-gray-2"
 						@click="open = false"
 					>
 						<FeatherIcon name="x" class="h-3.5 w-3.5" />
@@ -45,7 +78,7 @@ function timeAgo(ds) {
 				</div>
 				<div class="flow-scrollbar max-h-72 overflow-y-auto p-1">
 					<button
-						v-for="s in sessions"
+						v-for="s in list"
 						:key="s.name"
 						class="flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left hover:bg-surface-gray-2"
 						@click="choose(s.name)"
@@ -57,11 +90,14 @@ function timeAgo(ds) {
 							timeAgo(s.creation)
 						}}</span>
 					</button>
+					<div v-if="searching" class="px-2 py-4 text-center text-xs text-ink-gray-5">
+						{{ __("Searching…") }}
+					</div>
 					<div
-						v-if="!sessions.length"
+						v-else-if="!list.length"
 						class="px-2 py-4 text-center text-xs text-ink-gray-5"
 					>
-						{{ __("No recent sessions") }}
+						{{ query.trim() ? __("No matching sessions") : __("No recent sessions") }}
 					</div>
 				</div>
 			</div>

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -54,7 +54,7 @@ async function loadInitial() {
 	const [a, m] = await Promise.all([api.loadAgents(), api.loadModels(), refreshHistory()]);
 	agents.value = a;
 	models.value = m;
-	const assistant = a.find((x) => x.name === "Assistant");
+	const assistant = a.find((x) => x.name === "Flow");
 	selectedAgent.value = assistant ? assistant.name : a[0]?.name ?? null;
 	loaded.value = true;
 	focusTick.value++;


### PR DESCRIPTION
- **Rename** the system default agent `Assistant` → `Flow` (panel branding, empty state, and the agent record).
- **Composer height**: reset the textarea height after sending so it collapses back from a grown/attachment state.
- **Session search**: debounced search across the user's sessions in the Recent sessions menu.
- **Dropdown bounds**: clamp the agent/model dropdown menus so they stay inside the panel at narrow widths.