### PR TITLE
feat: auto-approve tool calls for unattended triggers

### DIFF
--- a/flow/ai/doctype/ai_agent/ai_agent.py
+++ b/flow/ai/doctype/ai_agent/ai_agent.py
@@ -134,6 +134,7 @@ class AIAgent(Document):
 		trigger: str | None = None,
 		reference_doctype: str | None = None,
 		reference_name: str | None = None,
+		auto_approve: bool = False,
 		stream: bool = False,
 	) -> AIRun | Generator[Event]:
 		"""Run `input` and persist as an AI Run. Convenience wrapper over the session API:
@@ -147,6 +148,7 @@ class AIAgent(Document):
 			trigger=trigger,
 			reference_doctype=reference_doctype,
 			reference_name=reference_name,
+			auto_approve=auto_approve,
 			stream=stream,
 		)
 

--- a/flow/ai/doctype/ai_session/ai_session.py
+++ b/flow/ai/doctype/ai_session/ai_session.py
@@ -126,6 +126,7 @@ class AISession(Document):
 		trigger: str | None = None,
 		reference_doctype: str | None = None,
 		reference_name: str | None = None,
+		auto_approve: bool = False,
 		stream: bool = False,
 	) -> AIRun | Generator[Event]:
 		"""Run one turn and persist it as an AI Run. `attachments` are File names whose text
@@ -150,6 +151,10 @@ class AISession(Document):
 		self._persist_turn(input, attachment_data, run.name)
 		self._index_retrieval_attachments(run.name)
 		run_input = self._build_prompt_messages()
+
+		# Opt-in (set on the AI Trigger): run confirmation tools without approval so unattended
+		# trigger runs don't park in Paused waiting for a confirmation no one can give.
+		self._runtime.auto_approve = auto_approve
 
 		if stream:
 			return stream_with_persistence(lambda: self._runtime.run(run_input, stream=True), run)

--- a/flow/ai/doctype/ai_trigger/ai_trigger.json
+++ b/flow/ai/doctype/ai_trigger/ai_trigger.json
@@ -11,6 +11,7 @@
   "column_break_meta",
   "agent",
   "event",
+  "auto_approve",
   "section_break_when",
   "target_doctype",
   "doc_event",
@@ -63,6 +64,13 @@
    "label": "Event",
    "options": "DocType Event\nScheduled",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "description": "Run this trigger's tool calls without asking for approval. Required for unattended triggers — otherwise the run pauses waiting for a confirmation.",
+   "fieldname": "auto_approve",
+   "fieldtype": "Check",
+   "label": "Auto Approve Tool Calls"
   },
   {
    "fieldname": "section_break_when",

--- a/flow/ai/doctype/ai_trigger/ai_trigger.py
+++ b/flow/ai/doctype/ai_trigger/ai_trigger.py
@@ -20,6 +20,7 @@ class AITrigger(Document):
 		from frappe.types import DF
 
 		agent: DF.Link
+		auto_approve: DF.Check
 		condition: DF.Code | None
 		cron_expression: DF.Data | None
 		doc_event: DF.Literal[None, "after_insert", "on_update", "on_submit", "on_cancel", "on_trash"]

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -92,10 +92,13 @@ class Agent:
 		tools: list[Tool] | None = None,
 		knowledge: Knowledge | list[Knowledge] | None = None,
 		max_iterations: int = DEFAULT_MAX_ITERATIONS,
+		auto_approve: bool = False,
 	):
 		if max_iterations < 1:
 			raise ValueError("max_iterations must be at least 1")
 
+		# Autonomous runs (triggers) auto-run confirmation tools; nobody is there to approve.
+		self.auto_approve = auto_approve
 		self.name = name
 		self.model = Model(model) if isinstance(model, str) else model
 		self.instructions = instructions
@@ -354,7 +357,7 @@ class Agent:
 		tool = self._tools_by_name.get(call.name)
 		if tool is None:
 			return json.dumps({"error": f"Unknown tool: {call.name!r}"})
-		if tool.requires_confirmation:
+		if tool.requires_confirmation and not self.auto_approve:
 			return _confirmation_question(call, tool)
 		return self._run_tool(call)
 

--- a/flow/tests/test_ai_agent.py
+++ b/flow/tests/test_ai_agent.py
@@ -610,6 +610,19 @@ class TestAgentConfirmation(UnitTestCase):
 		self.assertIn("write_file", result.questions[0].prompt)
 		self.assertEqual(calls, [])  # tool never ran
 
+	def test_auto_approve_runs_confirmation_tool_without_pausing(self):
+		write_file, calls = self._danger_tool()
+		model = FakeModel(
+			[_tool_call("write_file", {"path": "/tmp/x", "body": "hi"}, call_id="c1"), _final("done")]
+		)
+		agent = Agent(model=model, tools=[write_file], auto_approve=True)
+
+		result = agent.run("write hi to /tmp/x")
+
+		self.assertFalse(result.paused)
+		self.assertEqual(calls, [{"path": "/tmp/x", "body": "hi"}])  # ran unattended
+		self.assertEqual(result.output, "done")
+
 	def test_approve_invokes_tool_and_feeds_real_result_to_llm(self):
 		write_file, calls = self._danger_tool()
 		pause_response = _tool_call("write_file", {"path": "/tmp/x", "body": "hi"}, call_id="c1")

--- a/flow/tests/test_ai_triggers.py
+++ b/flow/tests/test_ai_triggers.py
@@ -245,6 +245,39 @@ class TestFire(IntegrationTestCase):
 		self.assertEqual(run.reference_doctype, "ToDo")
 		self.assertEqual(run.reference_name, todo.name)
 
+	def _execute_then_final(self):
+		from flow.lib.model import ToolCall
+
+		return [
+			ChatResponse(
+				content=None,
+				tool_calls=[ToolCall(id="c1", name="execute", arguments={"code": "result = 1"})],
+				finish_reason="tool_calls",
+			),
+			_final("done"),
+		]
+
+	def test_fire_auto_approves_confirmation_tools_when_enabled(self):
+		# auto_approve trigger: the requires_confirmation tool (execute) runs unattended
+		# instead of parking the run in Paused.
+		self.trigger.auto_approve = 1
+		self.trigger.save()
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "auto-approve"}).insert()
+
+		with patch.object(Model, "chat", side_effect=self._execute_then_final()):
+			run_name = fire(self.trigger.name, target_doctype="ToDo", target_name=todo.name)
+
+		self.assertEqual(frappe.get_doc("AI Run", run_name).status, "Completed")
+
+	def test_fire_pauses_on_confirmation_tool_without_auto_approve(self):
+		# Default trigger (auto_approve off): a confirmation tool still pauses for approval.
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "needs approval"}).insert()
+
+		with patch.object(Model, "chat", side_effect=self._execute_then_final()):
+			run_name = fire(self.trigger.name, target_doctype="ToDo", target_name=todo.name)
+
+		self.assertEqual(frappe.get_doc("AI Run", run_name).status, "Paused")
+
 	def test_fire_skips_disabled_trigger(self):
 		self.trigger.enabled = 0
 		self.trigger.save()

--- a/flow/triggers/triggers.py
+++ b/flow/triggers/triggers.py
@@ -87,6 +87,7 @@ def fire(
 		trigger=t.name,
 		reference_doctype=target_doctype if doc else None,
 		reference_name=target_name if doc else None,
+		auto_approve=bool(t.auto_approve),
 	)
 	return run.name
 


### PR DESCRIPTION
Triggers that call \`requires_confirmation\` tools (execute, create, update, delete) park in \`Paused\` indefinitely — no one is there to approve them.

Adds an opt-in **Auto Approve Tool Calls** checkbox on AI Trigger. When ticked, tool calls run unattended. When unticked (default), the run still pauses.

- \`AI Trigger\` — new \`auto_approve\` Check field (default off)
- \`Agent\` — \`auto_approve: bool = False\` gates the confirmation-question skip in \`_invoke()\`
- Threaded through \`triggers.fire()\` → \`ai_agent.run()\` → \`ai_session.chat()\` → \`self._runtime.auto_approve\`
- Tests: unit test (auto_approve=True runs confirmation tool without pausing) + two integration tests (enabled → Completed, default → Paused)