### PR TITLE
feat: assistant knowledge-base guidance and delete-link fixes

### DIFF
--- a/flow/assistant/assistant.py
+++ b/flow/assistant/assistant.py
@@ -33,7 +33,9 @@ ASSISTANT_INSTRUCTIONS = (
 	"- A single action the user wants now → just call the tools. Do NOT create an Agent.\n"
 	'- Something recurring, named, or conditional ("an agent that…", "every Friday…", '
 	'"whenever X happens…") → create a Flow Agent row, plus a Flow Trigger row (Scheduled or DocType '
-	"Event) when it must fire on its own. Show the exact JSON and ask for confirmation before "
+	"Event) when it must fire on its own. On the Flow Trigger set auto_approve=1 unless the user says "
+	"otherwise — a trigger runs unattended, so any tool call needing confirmation would stall forever "
+	"without it. Show the exact JSON and ask for confirmation before "
 	"inserting; do not also run the action inline.\n\n"
 	"BUILDING AN AGENT — reuse, don't reinvent. The builtin tools (find_doctypes, describe, read, "
 	"create, update, delete, run_action) already cover all standard Frappe work: reading, writing, "
@@ -42,6 +44,12 @@ ASSISTANT_INSTRUCTIONS = (
 	"a new Flow Tool (type 'Script') when the agent genuinely needs something outside them, e.g. calling "
 	"an external service or a specialized reusable routine. Never grant an agent the execute tool "
 	"unless the user explicitly asks for it.\n\n"
+	"GIVING AN AGENT KNOWLEDGE — when the user wants the agent to answer from specific material (a "
+	"document, URL, file, or pasted text), create a Flow Knowledge Base, then add one Flow Knowledge "
+	"Source row per item (knowledge_base = the base; source_type is Text/File/URL/DocType with the "
+	"matching input field — content, file, url, or reference_doctype+filters), and link the base to "
+	"the agent through its knowledge_bases table. The knowledge-search tool is attached automatically "
+	"once a base is bound.\n\n"
 	"WRITING A FLOW TOOL (Script) — only when truly needed: the code defines a top-level main(...) that "
 	"RETURNS its result (a `result` variable is ignored here — that is execute-only). Type-annotate "
 	"main's parameters; they become the input schema. No *args/**kwargs, and don't call main() "

--- a/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.js
+++ b/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.js
@@ -15,7 +15,7 @@ frappe.ui.form.on("Flow Knowledge Source", {
 		};
 
 		frm.add_custom_button(__("Resync"), async () => {
-			await frm.call("resync");
+			await frm.call("resync", { rebuild: 0 });
 			frappe.show_alert({ message: __("Resync started"), indicator: "blue" });
 			frm.reload_doc();
 		});

--- a/flow/hooks.py
+++ b/flow/hooks.py
@@ -36,9 +36,10 @@ doc_events = {
 	}
 }
 
-# A knowledge chunk indexes a referenced doc; it must never block deleting that
-# doc. The incremental sweep removes the orphaned chunk afterwards.
-ignore_links_on_delete = ["Flow Knowledge Chunk"]
+# Flow's references to other docs are bookkeeping — they must never block deleting
+# the referenced doc. A knowledge chunk indexes a doc; a Flow Run records the doc a
+# trigger acted on. The incremental sweep removes orphaned chunks afterwards.
+ignore_links_on_delete = ["Flow Knowledge Chunk", "Flow Run"]
 
 default_log_clearing_doctypes = {
 	"Flow Session": 90,


### PR DESCRIPTION
Stacked on #39 (AI→Flow rename) — uses Flow naming throughout. Rebase base back to `develop` once #39 merges.

- **assistant.py**: guide the assistant to set `auto_approve=1` on Flow Triggers (they run unattended) and to wire up Flow Knowledge Base / Flow Knowledge Source rows when an agent needs to answer from specific material.
- **hooks.py**: add `Flow Run` to `ignore_links_on_delete` so a run record never blocks deleting the doc a trigger acted on.
- **flow_knowledge_source.js**: pass `rebuild: 0` to the resync call.