### PR TITLE
feat: make Flow Model context window read-only and code-derived

### DIFF
--- a/flow/flow/doctype/flow_model/flow_model.json
+++ b/flow/flow/doctype/flow_model/flow_model.json
@@ -52,11 +52,12 @@
    "reqd": 1
   },
   {
-   "description": "Max input tokens. Auto-detected from the model on save when left empty; override if your provider differs. 0 = unknown.",
+   "description": "Max input tokens. Auto-detected from the model on save; managed by Flow, not user-editable. 0 = unknown.",
    "fieldname": "context_window",
    "fieldtype": "Int",
    "label": "Context Window",
-   "non_negative": 1
+   "non_negative": 1,
+   "read_only": 1
   },
   {
    "description": "API key for the provider named in the Model ID. Leave empty for local servers (Ollama, LM Studio) that don't require authentication.",

--- a/flow/flow/doctype/flow_model/flow_model.py
+++ b/flow/flow/doctype/flow_model/flow_model.py
@@ -104,11 +104,8 @@ class FlowModel(Document):
 			)
 
 	def _resolve_context_window(self):
-		# Auto-detect only when empty, or when the model changed on an existing doc. A value
-		# set by hand is kept — including one provided at creation. If litellm doesn't know
-		# the model, leave the existing value (callers fall back to a default when it's 0).
-		if self.context_window and (self.is_new() or not self.has_value_changed("model_id")):
-			return
+		# Always derived from the model — never user input. Keeps the last detected value when
+		# litellm can't resolve the model, and 0 otherwise (callers fall back to a default).
 		self.context_window = _detect_context_window(self.model_id) or self.context_window or 0
 
 	def _validate_provider_known(self):

--- a/flow/flow/doctype/flow_model/test_flow_model.py
+++ b/flow/flow/doctype/flow_model/test_flow_model.py
@@ -157,22 +157,14 @@ class TestContextWindow(IntegrationTestCase):
 		with patch("litellm.get_model_info", return_value={}):
 			self.assertEqual(_detect_context_window("vendor/x"), 0)
 
-	def test_auto_fills_when_empty_on_insert(self):
+	def test_auto_fills_on_insert(self):
 		with patch("litellm.get_model_info", return_value={"max_input_tokens": 128000}):
 			doc = frappe.get_doc(_model()).insert()
 		self.assertEqual(doc.context_window, 128000)
 
-	def test_manual_value_preserved_when_model_unchanged(self):
-		with patch("litellm.get_model_info", return_value={"max_input_tokens": 128000}):
-			doc = frappe.get_doc(_model(context_window=50000)).insert()
-			self.assertEqual(doc.context_window, 50000)  # manual value kept, not overwritten
-			doc.title = "Renamed"
-			doc.save()
-		self.assertEqual(doc.context_window, 50000)
-
 	def test_redetects_on_model_id_change(self):
 		with patch("litellm.get_model_info", return_value={"max_input_tokens": 128000}):
-			doc = frappe.get_doc(_model(context_window=50000)).insert()
+			doc = frappe.get_doc(_model()).insert()
 		# New model id (valid provider) -> re-detect, overriding the prior value.
 		with patch("litellm.get_model_info", return_value={"max_input_tokens": 1000000}) as m:
 			doc.model_id = "anthropic/claude-x"
@@ -182,9 +174,9 @@ class TestContextWindow(IntegrationTestCase):
 
 	def test_keeps_existing_when_new_model_unmapped(self):
 		with patch("litellm.get_model_info", return_value={"max_input_tokens": 128000}):
-			doc = frappe.get_doc(_model(context_window=50000)).insert()
-		# Valid provider, but litellm can't map the model -> keep the prior value.
+			doc = frappe.get_doc(_model()).insert()
+		# Valid provider, but litellm can't map the model -> keep the prior detected value.
 		with patch("litellm.get_model_info", side_effect=Exception("not mapped")):
 			doc.model_id = "anthropic/made-up-model-xyz"
 			doc.save()
-		self.assertEqual(doc.context_window, 50000)
+		self.assertEqual(doc.context_window, 128000)

--- a/flow/flow/doctype/flow_session/test_flow_session.py
+++ b/flow/flow/doctype/flow_session/test_flow_session.py
@@ -224,9 +224,9 @@ class TestAttachmentBudget(IntegrationTestCase):
 				"doctype": "Flow Model",
 				"title": "CW Model",
 				"model_id": "openai/gpt-4o-mini",
-				"context_window": 9000,
 			}
 		).insert()
+		frappe.db.set_value("Flow Model", model.name, "context_window", 9000)
 		self.assertEqual(self._session({"model": model.name})._context_window(), 9000)
 
 	def test_inline_threshold_is_fraction_of_window(self):
@@ -244,8 +244,9 @@ class TestAttachmentBudget(IntegrationTestCase):
 
 	def test_budget_floors_at_zero(self):
 		model = frappe.get_doc(
-			{"doctype": "Flow Model", "title": "Tiny", "model_id": "openai/gpt-4o-mini", "context_window": 1}
+			{"doctype": "Flow Model", "title": "Tiny", "model_id": "openai/gpt-4o-mini"}
 		).insert()
+		frappe.db.set_value("Flow Model", model.name, "context_window", 1)
 		s = self._session({"model": model.name})
 		s.append("messages", {"role": "user", "content": "x" * 10000, "run": None})
 		s.save(ignore_permissions=True)


### PR DESCRIPTION
The `context_window` field on Flow Model is now managed entirely by Flow — users no longer set or override it.

- **flow_model.json**: field is `read_only` (visible so users can see the detected value, but not editable).
- **flow_model.py**: `_resolve_context_window` now always derives the value from the model via litellm on save, instead of preserving a hand-set value. Falls back to the last detected value when litellm can't resolve the model.
- **tests**: dropped the obsolete manual-value-preservation test; session budget tests set the value via `db.set_value` to simulate the code-filled field.

Verified: 21/21 model tests, 36/36 session tests pass.