### PR TITLE
feat: hide trigger sessions from chat recents

### DIFF
--- a/flow/flow/doctype/flow_agent/flow_agent.py
+++ b/flow/flow/doctype/flow_agent/flow_agent.py
@@ -143,7 +143,7 @@ class FlowAgent(Document):
 		starts a conversation (or continues `session`) and calls `chat()`."""
 		from flow.lib.session import load_session, new_session
 
-		convo = load_session(session, agent=self.name) if session else new_session(self)
+		convo = load_session(session, agent=self.name) if session else new_session(self, source=source)
 		return convo.chat(
 			input,
 			source=source,

--- a/flow/flow/doctype/flow_session/flow_session.json
+++ b/flow/flow/doctype/flow_session/flow_session.json
@@ -8,6 +8,7 @@
   "title",
   "agent",
   "model",
+  "source",
   "section_break_transcript",
   "messages",
   "attachments"
@@ -37,6 +38,16 @@
    "in_standard_filter": 1,
    "label": "Model",
    "options": "Flow Model"
+  },
+  {
+   "default": "Manual",
+   "description": "How this conversation was started. Trigger sessions are hidden from the chat panel's recent list.",
+   "fieldname": "source",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "Source",
+   "options": "Manual\nTrigger",
+   "read_only": 1
   },
   {
    "collapsible": 1,

--- a/flow/flow/doctype/flow_session/flow_session.py
+++ b/flow/flow/doctype/flow_session/flow_session.py
@@ -48,6 +48,7 @@ class FlowSession(Document):
 		attachments: DF.Table[FlowSessionAttachment]
 		messages: DF.Table[FlowSessionMessage]
 		model: DF.Link | None
+		source: DF.Literal["Manual", "Trigger"]
 		title: DF.Data | None
 	# end: auto-generated types
 

--- a/flow/lib/session.py
+++ b/flow/lib/session.py
@@ -14,9 +14,12 @@ if TYPE_CHECKING:
 	from flow.lib.agent import Agent
 
 
-def new_session(agent: Any = None, *, model: str | None = None, title: str | None = None) -> FlowSession:
+def new_session(
+	agent: Any = None, *, model: str | None = None, title: str | None = None, source: str = "Manual"
+) -> FlowSession:
 	"""Start a conversation. `agent` may be a code `Agent`, a Flow Agent doc, an agent name,
-	or None for the default Assistant. Code agents leave the session's agent link empty."""
+	or None for the default Assistant. Code agents leave the session's agent link empty.
+	`source` records how it was started; "Trigger" sessions are hidden from the chat panel."""
 	runtime, agent_name, session_model, snapshot = _resolve_new_agent(agent, model)
 	doc = frappe.get_doc(
 		{
@@ -24,6 +27,7 @@ def new_session(agent: Any = None, *, model: str | None = None, title: str | Non
 			"agent": agent_name,
 			"model": session_model,
 			"title": title,
+			"source": source,
 		}
 	).insert(ignore_permissions=True)
 	doc._runtime = runtime

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -11,9 +11,9 @@ export const loadModels = () =>
 
 export const loadHistory = () =>
 	getList("Flow Session", {
-		filters: { owner: frappe.session.user },
-		fields: ["name", "title", "creation"],
-		order_by: "creation desc",
+		filters: { owner: frappe.session.user, source: ["!=", "Trigger"] },
+		fields: ["name", "title", "modified"],
+		order_by: "modified desc",
 		limit: 15,
 	});
 
@@ -22,9 +22,13 @@ const escapeLike = (s) => s.replace(/[\\%_]/g, "\\$&");
 
 export const searchSessions = (query) =>
 	getList("Flow Session", {
-		filters: { owner: frappe.session.user, title: ["like", `%${escapeLike(query)}%`] },
-		fields: ["name", "title", "creation"],
-		order_by: "creation desc",
+		filters: {
+			owner: frappe.session.user,
+			source: ["!=", "Trigger"],
+			title: ["like", `%${escapeLike(query)}%`],
+		},
+		fields: ["name", "title", "modified"],
+		order_by: "modified desc",
 		limit: 20,
 	});
 

--- a/frontend/src/components/SessionsMenu.vue
+++ b/frontend/src/components/SessionsMenu.vue
@@ -90,7 +90,7 @@ function timeAgo(ds) {
 							s.title || s.name
 						}}</span>
 						<span class="shrink-0 text-[11px] text-ink-gray-5">{{
-							timeAgo(s.creation)
+							timeAgo(s.modified)
 						}}</span>
 					</button>
 					<div v-if="searching" class="px-2 py-4 text-center text-xs text-ink-gray-5">


### PR DESCRIPTION
Trigger runs created Flow Sessions that showed up in the chat panel's recent list. Sessions still need to exist (they hold the transcript for debugging), so instead of dropping them we tag and filter.

- **Flow Session** gains a `source` field (`Manual` / `Trigger`, mirroring `Flow Run.source`).
- `agent.run(source=...)` threads the source into `new_session`, so a session is tagged `Trigger` **only** when fired through a trigger — programmatic `agent.run()` and chat (`start_run`) stay `Manual`.
- Frontend recents/search filter `source != "Trigger"` and now sort by `modified desc` (most recent interaction) instead of creation.

Trigger transcripts remain fully available in the desk (Flow Session list / linked from the Flow Run). No backfill patch — Flow is pre-launch, no existing data.

Verified: trigger→`Trigger`, chat→`Manual`; 73 tests pass (triggers/session/agent); frontend builds.