### PR TITLE
fix: migrate __Auth password rows in AI to Flow rename

### DIFF
--- a/flow/patches/rename_ai_to_flow.py
+++ b/flow/patches/rename_ai_to_flow.py
@@ -49,6 +49,11 @@ def _rename_ai_to_flow():
 		if frappe.db.exists("DocType", old) and not frappe.db.exists("DocType", new):
 			frappe.rename_doc("DocType", old, new, force=True)
 
+	# Password fields (e.g. api_key) live in __Auth keyed by doctype name; the doctype
+	# rename doesn't migrate them, so repoint them or every saved key reads as missing.
+	for old, new in DOCTYPE_RENAMES.items():
+		frappe.db.sql("update `__Auth` set doctype=%s where doctype=%s", (new, old))
+
 	# Workspaces are pure JSON config; drop the old ones so sync recreates them as Flow.
 	for ws in ("Workspace", "Workspace Sidebar"):
 		if frappe.db.exists(ws, "AI"):


### PR DESCRIPTION
Frappe's DocType rename doesn't migrate the `__Auth` table (where password fields like `api_key` are stored, keyed by doctype name). So after the AI→Flow rename, every saved provider/model API key stayed under `AI Provider`/`AI Model` while the records became `Flow Provider`/`Flow Model` — `get_password("api_key")` then returned nothing, breaking every model with `OpenAIException - Missing credentials`.

The rename patch now repoints `__Auth.doctype` for each renamed doctype. Idempotent (no-op once migrated).

Tested end-to-end: brought a site to pristine AI state and ran a one-shot `bench migrate` — no AI leftovers, `__Auth` rows moved to Flow names, and credentials resolve (provider key, model resolution, per-model keys all confirmed).