### PR TITLE
feat: structured Flow Run detail + panel shortcut

### DIFF
--- a/flow/flow/doctype/flow_run/flow_run.js
+++ b/flow/flow/doctype/flow_run/flow_run.js
@@ -2,6 +2,24 @@
 // License: MIT. See LICENSE
 
 frappe.ui.form.on("Flow Run", {
-	// refresh(frm) {
-	// },
+	refresh(frm) {
+		const parse = (value) => {
+			if (!value) return null;
+			if (typeof value === "object") return value;
+			try {
+				return JSON.parse(value);
+			} catch {
+				return null;
+			}
+		};
+
+		frm.get_field("detail_html").$wrapper.html(
+			frappe.render_template("flow_run_detail", {
+				usage: parse(frm.doc.usage),
+				config: parse(frm.doc.config_snapshot),
+				calls: parse(frm.doc.tool_calls),
+				questions: parse(frm.doc.questions),
+			})
+		);
+	},
 });

--- a/flow/flow/doctype/flow_run/flow_run.json
+++ b/flow/flow/doctype/flow_run/flow_run.json
@@ -16,13 +16,11 @@
   "section_break_io",
   "input",
   "output",
-  "section_break_calls",
+  "section_break_detail",
+  "detail_html",
   "tool_calls",
-  "section_break_pause",
   "questions",
-  "section_break_usage",
   "usage",
-  "section_break_snapshot",
   "config_snapshot",
   "section_break_error",
   "error"
@@ -115,54 +113,43 @@
    "read_only": 1
   },
   {
-   "collapsible": 1,
-   "fieldname": "section_break_calls",
+   "fieldname": "section_break_detail",
    "fieldtype": "Section Break",
-   "label": "Tool Calls"
+   "label": "Detail"
+  },
+  {
+   "fieldname": "detail_html",
+   "fieldtype": "HTML",
+   "label": "Detail"
   },
   {
    "description": "List of tool calls the agent executed.",
    "fieldname": "tool_calls",
    "fieldtype": "JSON",
+   "hidden": 1,
    "label": "Tool Calls",
    "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "depends_on": "eval:doc.status === 'Paused'",
-   "fieldname": "section_break_pause",
-   "fieldtype": "Section Break",
-   "label": "Pending Questions"
   },
   {
    "description": "Questions waiting on a user answer. Present only when status is Paused.",
    "fieldname": "questions",
    "fieldtype": "JSON",
+   "hidden": 1,
    "label": "Questions",
    "read_only": 1
   },
   {
-   "collapsible": 1,
-   "fieldname": "section_break_usage",
-   "fieldtype": "Section Break",
-   "label": "Usage"
-  },
-  {
    "fieldname": "usage",
    "fieldtype": "JSON",
+   "hidden": 1,
    "label": "Token Usage",
    "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "section_break_snapshot",
-   "fieldtype": "Section Break",
-   "label": "Config Snapshot"
   },
   {
    "description": "Agent configuration captured at run start (instructions + tool slugs).",
    "fieldname": "config_snapshot",
    "fieldtype": "JSON",
+   "hidden": 1,
    "label": "Config Snapshot",
    "read_only": 1
   },

--- a/flow/flow/doctype/flow_run/flow_run_detail.html
+++ b/flow/flow/doctype/flow_run/flow_run_detail.html
@@ -1,0 +1,64 @@
+<style>
+.flow-run h6 { font-size: var(--text-md); font-weight: 420; color: #525252; margin: 44px 0 12px; }
+.flow-run h6:first-child { margin-top: 0; }
+.flow-run table.usage { width: auto; margin: 0; }
+.flow-run table thead th { font-weight: 500; }
+.flow-run table.config { width: 100%; margin: 0; }
+.flow-run table.config th { width: 140px; font-weight: 420; color: var(--text-muted); white-space: nowrap; vertical-align: top; }
+.flow-run pre.args { white-space: pre-wrap; word-break: break-word; font-size: 12px; margin: 0; }
+.flow-run .instructions { white-space: pre-wrap; word-break: break-word; max-height: 280px; overflow: auto; font-size: 13px; line-height: 1.5; }
+.flow-run table.calls { width: 100%; margin: 0; font-size: 12px; }
+.flow-run .empty { color: var(--text-muted); }
+</style>
+{% var esc = (v) => frappe.utils.escape_html(v == null ? "" : String(v)); %}
+{% var nf = (n) => Number(n || 0).toLocaleString(); %}
+{% var hasKeys = (o) => o && Object.keys(o).length; %}
+<div class="flow-run">
+
+{% if usage %}
+<h6>{{ __("Token Usage") }}</h6>
+<table class="table table-bordered usage">
+	<thead><tr><th>{{ __("Prompt") }}</th><th>{{ __("Completion") }}</th><th>{{ __("Total") }}</th></tr></thead>
+	<tbody><tr><td>{{ nf(usage.prompt_tokens) }}</td><td>{{ nf(usage.completion_tokens) }}</td><td>{{ nf(usage.total_tokens) }}</td></tr></tbody>
+</table>
+{% endif %}
+
+{% if config %}
+<h6>{{ __("Config Snapshot") }}</h6>
+<table class="table table-bordered config">
+	<tbody>
+		<tr><th>{{ __("Title") }}</th><td>{{ esc(config.title || "—") }}</td></tr>
+		<tr><th>{{ __("Model") }}</th><td>{{ esc(config.model || "—") }}</td></tr>
+		<tr><th>{{ __("Max Iterations") }}</th><td>{{ esc(config.max_iterations || "—") }}</td></tr>
+		<tr><th>{{ __("Tools") }}</th><td>{% if config.tools && config.tools.length %}{% for t in config.tools %}<span class="indicator-pill gray" style="margin: 0 4px 4px 0;">{{ esc(t) }}</span>{% endfor %}{% else %}<span class="empty">—</span>{% endif %}</td></tr>
+		{% if config.instructions %}<tr><th>{{ __("Instructions") }}</th><td><div class="instructions">{{ esc(config.instructions) }}</div></td></tr>{% endif %}
+	</tbody>
+</table>
+{% endif %}
+
+{% if calls && calls.length %}
+<h6>{{ __("Tool Calls") }}</h6>
+<table class="table table-bordered calls">
+	<thead><tr><th style="width: 32px;">#</th><th>{{ __("Tool") }}</th><th>{{ __("Arguments") }}</th></tr></thead>
+	<tbody>
+{% for c in calls %}
+		<tr>
+			<td class="text-muted">{{ c._index + 1 }}</td>
+			<td style="white-space: nowrap;"><code>{{ esc(c.name) }}</code></td>
+			<td>{% if hasKeys(c.arguments) %}<pre class="args">{{ esc(JSON.stringify(c.arguments, null, 2)) }}</pre>{% else %}<span class="empty">—</span>{% endif %}</td>
+		</tr>
+{% endfor %}
+	</tbody>
+</table>
+{% endif %}
+
+{% if questions && questions.length %}
+<h6>{{ __("Pending Questions") }}</h6>
+<ul style="margin: 0; padding-left: 18px;">
+{% for q in questions %}
+	<li style="margin-bottom: 8px;"><div>{{ esc(q.prompt) }}</div>{% if q.options && q.options.length %}<div class="text-muted" style="margin-top: 2px;">{{ q.multi_select ? __("Select any") : __("Select one") }}: {{ q.options.map(o => esc(o)).join(", ") }}</div>{% endif %}</li>
+{% endfor %}
+</ul>
+{% endif %}
+
+</div>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -99,7 +99,7 @@ class FlowPanel {
 
 	_registerShortcut() {
 		frappe.ui.keys.add_shortcut({
-			shortcut: "ctrl+m",
+			shortcut: "ctrl+i",
 			action: () => this.toggle(),
 			description: __("Toggle Flow panel"),
 			ignore_inputs: false,


### PR DESCRIPTION
## What

- Render Flow Run's JSON fields (token usage, config snapshot, tool calls, pending questions) as structured tables via a co-located HTML template instead of raw JSON blobs. Raw JSON fields are now hidden.
- Change the Flow panel toggle shortcut from Ctrl/Cmd+M (collides with macOS minimize) to Ctrl/Cmd+I.

## Notes

- All dynamic values pass through `frappe.utils.escape_html()` — no injection surface.
- Template auto-registered by Frappe's `add_html_templates()`; no build step.