### PR TITLE
feat: auto-scroll chat and refocus composer after send

### DIFF
--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -7,7 +7,7 @@ import { FeatherIcon } from "@/lib/ui";
 import { useStore } from "@/store";
 import { __ } from "@/lib/translate";
 
-const { messages, needsSetup, agents, models, scrollTick } = useStore();
+const { messages, needsSetup, agents, models, scrollTick, forceScroll } = useStore();
 
 const el = ref(null);
 let frame = 0;
@@ -21,7 +21,13 @@ function onScroll() {
 function scrollDown() {
 	frame = 0;
 	const e = el.value;
-	if (e && stick) e.scrollTop = e.scrollHeight;
+	if (e && (stick || forceScroll.value)) {
+		// Smooth for explicit actions (send / approval); instant while streaming
+		// so it doesn't lag behind a fast token stream.
+		e.scrollTo({ top: e.scrollHeight, behavior: forceScroll.value ? "smooth" : "auto" });
+		stick = true;
+	}
+	forceScroll.value = false;
 }
 
 // Coalesce burst scroll requests (one per frame) so a fast token stream doesn't

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -237,6 +237,7 @@ async function send(text) {
 	} finally {
 		sending.value = false;
 		requestScroll();
+		focusTick.value++;
 	}
 }
 
@@ -256,6 +257,7 @@ async function resume(answers, pausedMsg) {
 	} finally {
 		sending.value = false;
 		requestScroll();
+		focusTick.value++;
 	}
 }
 

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -30,6 +30,7 @@ const fullscreen = ref(false);
 
 // Bumped whenever new content arrives / focus is wanted; views watch & react.
 const scrollTick = ref(0);
+const forceScroll = ref(false);
 const focusTick = ref(0);
 
 // ── derived ───────────────────────────────────────────────────────────────
@@ -218,7 +219,7 @@ async function send(text) {
 	messages.value.push({ id: nextId(), role: "user", content: text, attachments: chips });
 	const assistant = pushAssistant();
 	sending.value = true;
-	requestScroll();
+	requestScroll(true);
 
 	try {
 		await startRun(
@@ -246,7 +247,7 @@ async function resume(answers, pausedMsg) {
 	pausedMsg.questions = [];
 	const assistant = pushAssistant();
 	sending.value = true;
-	requestScroll();
+	requestScroll(true);
 
 	try {
 		await resumeRun({ run_name: rn, answers }, (event) => handleEvent(event, assistant));
@@ -314,6 +315,7 @@ function handleEvent(event, msg) {
 			if (event.status === "Paused") {
 				msg.questions = prepareQuestions(event.questions);
 				msg.runName = runName.value;
+				requestScroll(true);
 			}
 			refreshHistory();
 			break;
@@ -377,7 +379,10 @@ function prepareQuestions(questions) {
 	}));
 }
 
-function requestScroll() {
+// force bypasses the "stick" guard — for explicit actions (sending, approval
+// cards) that must land at the bottom even if the user scrolled up.
+function requestScroll(force = false) {
+	if (force) forceScroll.value = true;
 	scrollTick.value++;
 }
 
@@ -396,6 +401,7 @@ export function useStore() {
 		loaded,
 		fullscreen,
 		scrollTick,
+		forceScroll,
 		focusTick,
 		// derived
 		locked,


### PR DESCRIPTION
## What

- Auto-scroll the chat to the bottom on explicit actions — sending a message, an approval card appearing, and resuming after an answer — even if the user had scrolled up. Streaming stays gentle (only follows when already near the bottom). Forced scrolls animate smoothly.
- Refocus the composer after a run completes so the user can type the next prompt without clicking back into the textarea.