### PR TITLE
fix: make panel shortcut fire while an input is focused

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -102,7 +102,7 @@ class FlowPanel {
 			shortcut: "ctrl+i",
 			action: () => this.toggle(),
 			description: __("Toggle Flow panel"),
-			ignore_inputs: false,
+			ignore_inputs: true,
 		});
 	}
 


### PR DESCRIPTION
## Problem

After a page load, Cmd/Ctrl+I didn't open the panel until the user clicked the desk. On load the composer textarea is auto-focused (even though the panel is hidden), so `document.activeElement` is an `<input>`. Frappe's shortcut handler bails when an input is focused unless `ignore_inputs` is set.

## Fix

Set `ignore_inputs: true` on the toggle shortcut — matching Frappe's own global toggles (Cmd+K, Cmd+G, Cmd+S). The panel now toggles from anywhere, including from inside inputs, right after load.