### PR TITLE
chore: auto-install and build frontend on bench setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "scripts": {
+    "postinstall": "cd frontend && yarn install",
+    "dev": "cd frontend && yarn dev",
+    "build": "cd frontend && yarn build"
+  }
+}


### PR DESCRIPTION
## What

Adds a root `package.json` that delegates to the `frontend/` Vite project:

```json
{
  "private": true,
  "scripts": {
    "postinstall": "cd frontend && yarn install",
    "dev": "cd frontend && yarn dev",
    "build": "cd frontend && yarn build"
  }
}
```

## Why

Bench's tooling only inspects an app's **root**. With no root `package.json`, a fresh `bench get-app`/`bench build` silently skips flow's `frontend/`, so the panel bundle in `flow/public/flow_panel/` (gitignored) is never built — currently requiring manual `yarn install` + `yarn build`.

With the root shim:
- `bench get-app` / `bench setup requirements` runs `yarn install` at the root → `postinstall` installs frontend deps.
- `bench build` finds the root `build` script (frappe's esbuild driver checks `apps/<app>/package.json` for a `build` script) → runs the Vite build.

Matches the convention used by helpdesk, studio, and otto.