### PR TITLE
fix: commit before model call so concurrent turns don't hit lock timeout

### DIFF
--- a/flow/flow/doctype/flow_session/flow_session.py
+++ b/flow/flow/doctype/flow_session/flow_session.py
@@ -153,6 +153,11 @@ class FlowSession(Document):
 		self._index_retrieval_attachments(run.name)
 		run_input = self._build_prompt_messages()
 
+		# Release row locks and publish the Running run before the long model call, so a
+		# concurrent turn doesn't block on the Flow Session row until lock timeout (1205).
+		if not frappe.flags.in_test:
+			frappe.db.commit()
+
 		# Opt-in (set on the Flow Trigger): run confirmation tools without approval so unattended
 		# trigger runs don't park in Paused waiting for a confirmation no one can give.
 		self._runtime.auto_approve = auto_approve
@@ -164,6 +169,9 @@ class FlowSession(Document):
 			result = self._runtime.run(run_input)
 		except Exception as e:
 			run.mark_failed(str(e))
+			# Persist Failed too; the Running run is already committed.
+			if not frappe.flags.in_test:
+				frappe.db.commit()
 			raise
 		run.apply_result(result)
 		return run

--- a/flow/flow/doctype/flow_session/flow_session.py
+++ b/flow/flow/doctype/flow_session/flow_session.py
@@ -131,7 +131,11 @@ class FlowSession(Document):
 		stream: bool = False,
 	) -> FlowRun | Generator[Event]:
 		"""Run one turn and persist it as a Flow Run. `attachments` are File names whose text
-		is injected into this turn's prompt. With `stream=True`, returns an event generator."""
+		is injected into this turn's prompt. With `stream=True`, returns an event generator.
+
+		Commits the current transaction before the model call (to release row locks). Do not
+		call with pending writes you may want to roll back on failure; commit-and-compensate
+		around it instead."""
 		from flow.flow.doctype.flow_run.flow_run import create_run, stream_with_persistence
 
 		self.reload()


### PR DESCRIPTION
The non-streaming `chat()` path held the request's DB transaction open across the whole model call, so Flow Session row locks were held for the run's duration. A concurrent turn on the same session blocked until `innodb_lock_wait_timeout` and died with `1205 Lock wait timeout exceeded`.

Commit after persisting the turn and creating the Running run, before the model call — releasing locks and publishing the Running run so `_assert_not_blocked` rejects overlapping turns cleanly. The streaming path already did this.

Tests: `test_session`, `test_flow_session`, `test_flow_run` pass.