### PR TITLE
fix: delete linked flow runs when a session is deleted

### DIFF
--- a/flow/flow/doctype/flow_session/flow_session.py
+++ b/flow/flow/doctype/flow_session/flow_session.py
@@ -57,6 +57,7 @@ class FlowSession(Document):
 		self._validate_model_enabled()
 
 	def on_trash(self):
+		frappe.db.delete("Flow Run", {"session": self.name})
 		_purge_attachment_chunks(self.name)
 
 	def _validate_model_enabled(self):

--- a/flow/flow/doctype/flow_session/test_flow_session.py
+++ b/flow/flow/doctype/flow_session/test_flow_session.py
@@ -392,6 +392,15 @@ class TestAttachmentCleanup(IntegrationTestCase):
 			frappe.delete_doc("Flow Session", s.name, ignore_permissions=True)
 		self.assertFalse(frappe.db.exists("Flow Session", s.name))
 
+	def test_on_trash_deletes_linked_runs(self):
+		s = frappe.get_doc({"doctype": "Flow Session"}).insert(ignore_permissions=True)
+		run = frappe.get_doc(
+			{"doctype": "Flow Run", "session": s.name, "source": "Manual", "status": "Completed"}
+		).insert(ignore_permissions=True)
+		with patch("flow.knowledge.attachment_store.delete"):
+			frappe.delete_doc("Flow Session", s.name, ignore_permissions=True)
+		self.assertFalse(frappe.db.exists("Flow Run", run.name))
+
 	def test_clear_old_logs_purges_chunks_for_batch(self):
 		s = frappe.get_doc({"doctype": "Flow Session", "title": "old"}).insert(ignore_permissions=True)
 		old = frappe.utils.add_days(frappe.utils.now(), -100)


### PR DESCRIPTION
Deleting a Flow Session left its Flow Runs orphaned (the runs link to the session via a required Link, but nothing cleaned them up on delete).

Cascade-delete linked runs in `FlowSession.on_trash`, which runs before the row is removed. The transcript/attachment child rows already cascade with the parent.

Test reproduces the orphan and verifies the cascade.