### PR TITLE
feat: surface knowledge base descriptions to the agent in the search tool

### DIFF
--- a/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.json
+++ b/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.json
@@ -33,7 +33,7 @@
    "fieldtype": "Section Break"
   },
   {
-   "description": "What this knowledge base contains and when an agent should search it.",
+   "description": "Shown to the agent: what this knowledge base contains and when to search it. Helps the agent decide whether to use it.",
    "fieldname": "description",
    "fieldtype": "Small Text",
    "label": "Description"
@@ -46,7 +46,7 @@
    "link_fieldname": "knowledge_base"
   }
  ],
- "modified": "2026-06-11 00:00:00",
+ "modified": "2026-07-04 00:00:02.000000",
  "modified_by": "Administrator",
  "module": "Flow",
  "name": "Flow Knowledge Base",

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -1133,6 +1133,16 @@ class TestAgentKnowledge(IntegrationTestCase):
 			search(query="hi")
 		mock.assert_called_once_with("hi", kbs=[first.name, second.name])
 
+	def test_kb_descriptions_appear_in_tool_description(self):
+		kb = Knowledge("Travel KB", description="Company travel and reimbursement policy.")
+		search = self._agent([kb])
+		self.assertIn("Travel KB", search.description)
+		self.assertIn("Company travel and reimbursement policy.", search.description)
+
+	def test_kb_without_description_leaves_base_description(self):
+		search = self._agent([Knowledge("Plain KB")])
+		self.assertNotIn("This agent's knowledge bases:", search.description)
+
 
 class TestAttachmentStore(IntegrationTestCase):
 	def setUp(self):

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -122,7 +122,23 @@ def bind_search_knowledge(kbs: list[str]) -> Tool:
 
 		return retrieve(query, kbs=kbs)
 
-	return tool(search_knowledge, description=_KNOWLEDGE_SEARCH_DESCRIPTION)
+	return tool(search_knowledge, description=_knowledge_search_description(kbs))
+
+
+def _knowledge_search_description(kbs: list[str]) -> str:
+	"""Append the bound knowledge bases' descriptions so the model knows what's searchable
+	and when to call the tool."""
+	if not kbs:
+		return _KNOWLEDGE_SEARCH_DESCRIPTION
+	rows = frappe.get_all(
+		"Flow Knowledge Base",
+		filters={"name": ["in", kbs], "enabled": 1},
+		fields=["title", "description"],
+	)
+	listed = "\n".join(f"- {r.title}: {r.description}" for r in rows if r.description)
+	if not listed:
+		return _KNOWLEDGE_SEARCH_DESCRIPTION
+	return f"{_KNOWLEDGE_SEARCH_DESCRIPTION}\n\nThis agent's knowledge bases:\n{listed}"
 
 
 search_knowledge = bind_search_knowledge([])


### PR DESCRIPTION
The Flow Knowledge Base `description` field was never fed to the model — its help text promised it guided the agent, but nothing wired it up.

Append each bound (enabled) KB's title + description to the `search_knowledge` tool description, so the agent knows what knowledge exists and when to call the tool. Injected into the tool description (not per-KB selection) since the tool searches all bound KBs at once.

Tests assert the descriptions land in the tool description and that a description-less KB leaves the base text unchanged.