### PR TITLE
feat: operate the Desk frontend from the Flow panel

### DIFF
--- a/flow/assistant/assistant.py
+++ b/flow/assistant/assistant.py
@@ -18,6 +18,9 @@ ASSISTANT_INSTRUCTIONS = (
 	"- describe(doctype, name=None): inspect fields and your permissions; pass a record name to also "
 	"list its actions (submit/cancel/amend/rename, workflow transitions, whitelisted methods).\n"
 	"- read(doctype, filters, fields, ...): load records before changing them.\n"
+	"- read_screen(): see the user's current Desk screen — the route and, for an open form, "
+	"its doctype, record, unsaved/mandatory state and values. Use it whenever the user refers "
+	'to what they are looking at ("this record", "this form", "why can\'t I submit this").\n'
 	"Discover → verify → act. Never invent a DocType, field, or record name.\n\n"
 	"ACTING — use the direct tool; reach for execute only when nothing else fits:\n"
 	"- create / update / delete: standard record writes.\n"

--- a/flow/flow/doctype/flow_tool/flow_tool.json
+++ b/flow/flow/doctype/flow_tool/flow_tool.json
@@ -12,6 +12,7 @@
   "type",
   "enabled",
   "requires_confirmation",
+  "client_tool",
   "is_system_generated",
   "section_break_description",
   "description",
@@ -64,6 +65,13 @@
    "fieldname": "requires_confirmation",
    "fieldtype": "Check",
    "label": "Requires Confirmation"
+  },
+  {
+   "default": "0",
+   "description": "Runs in the user's browser (the Flow panel), not on the server. The run pauses, the panel executes the tool against the live Desk, and its result is fed back to the agent. Imported client tools supply only the LLM-facing schema and description.",
+   "fieldname": "client_tool",
+   "fieldtype": "Check",
+   "label": "Client Tool"
   },
   {
    "description": "Tools created by Frappe and protected from deletion.",

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -185,7 +185,9 @@ class Agent:
 		for call in pending:
 			answer = answers.get(call.id)
 			tool = self._tools_by_name.get(call.name)
-			if tool is not None and tool.requires_confirmation:
+			if tool is not None and tool.client_tool:
+				content = _serialize_tool_result(answer)
+			elif tool is not None and tool.requires_confirmation:
 				content = self._resolve_confirmation(call, answer)
 			else:
 				content = _serialize_tool_result(answer)
@@ -361,12 +363,16 @@ class Agent:
 		tool = self._tools_by_name.get(call.name)
 		if tool is None:
 			return json.dumps({"error": f"Unknown tool: {call.name!r}"})
-		if tool.requires_confirmation and not self.auto_approve:
-			return _confirmation_question(call, tool)
 		if tool.client_tool:
 			if self.auto_approve:
 				return json.dumps({"error": f"{call.name} needs a browser and can't run unattended."})
+			if tool.requires_confirmation:
+				question = _confirmation_question(call, tool)
+				question.client_tool = True
+				return question
 			return Question(prompt=f"Running {call.name} in the browser…", client_tool=True)
+		if tool.requires_confirmation and not self.auto_approve:
+			return _confirmation_question(call, tool)
 		return self._run_tool(call)
 
 	def _run_tool(self, call: ToolCall) -> Any:

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -27,6 +27,9 @@ class Question:
 	multi-select. When `allow_other` is true the picker always offers an "Other"
 	choice that opens a textbox for the user to reiterate or redirect.
 	`key` routes the answer back (e.g. the tool_call_id it belongs to).
+
+	When `client_tool` is true the pause is resolved by the browser executing the named
+	client tool, not by a human — the panel runs it and resumes with the result.
 	"""
 
 	prompt: str
@@ -34,6 +37,7 @@ class Question:
 	multi_select: bool = False
 	allow_other: bool = True
 	key: str | None = None
+	client_tool: bool = False
 
 
 @dataclass
@@ -359,6 +363,10 @@ class Agent:
 			return json.dumps({"error": f"Unknown tool: {call.name!r}"})
 		if tool.requires_confirmation and not self.auto_approve:
 			return _confirmation_question(call, tool)
+		if tool.client_tool:
+			if self.auto_approve:
+				return json.dumps({"error": f"{call.name} needs a browser and can't run unattended."})
+			return Question(prompt=f"Running {call.name} in the browser…", client_tool=True)
 		return self._run_tool(call)
 
 	def _run_tool(self, call: ToolCall) -> Any:

--- a/flow/lib/resolver.py
+++ b/flow/lib/resolver.py
@@ -53,7 +53,9 @@ def _resolve_module(doc: FlowTool) -> Tool:
 		)
 
 	if isinstance(obj, Tool):
-		return _build_tool(doc, obj.parameters, obj.func, confirm_prompt=obj.confirm_prompt)
+		return _build_tool(
+			doc, obj.parameters, obj.func, confirm_prompt=obj.confirm_prompt, code_client_tool=obj.client_tool
+		)
 	if callable(obj):
 		return _build_tool(doc, build_schema(obj), obj)
 	frappe.throw(
@@ -67,7 +69,14 @@ def _resolve_script(doc: FlowTool, *, restrict_commit_rollback: bool = False) ->
 	return _build_tool(doc, schema_from_code(doc.code), runner)
 
 
-def _build_tool(doc: FlowTool, parameters: dict[str, Any], func: Any, *, confirm_prompt: Any = None) -> Tool:
+def _build_tool(
+	doc: FlowTool,
+	parameters: dict[str, Any],
+	func: Any,
+	*,
+	confirm_prompt: Any = None,
+	code_client_tool: bool = False,
+) -> Tool:
 	return Tool(
 		name=doc.slug,
 		description=doc.description,
@@ -75,7 +84,7 @@ def _build_tool(doc: FlowTool, parameters: dict[str, Any], func: Any, *, confirm
 		func=func,
 		requires_confirmation=bool(doc.requires_confirmation),
 		confirm_prompt=confirm_prompt,
-		client_tool=bool(doc.client_tool),
+		client_tool=bool(doc.client_tool) or code_client_tool,
 	)
 
 

--- a/flow/lib/resolver.py
+++ b/flow/lib/resolver.py
@@ -75,6 +75,7 @@ def _build_tool(doc: FlowTool, parameters: dict[str, Any], func: Any, *, confirm
 		func=func,
 		requires_confirmation=bool(doc.requires_confirmation),
 		confirm_prompt=confirm_prompt,
+		client_tool=bool(doc.client_tool),
 	)
 
 

--- a/flow/lib/tool.py
+++ b/flow/lib/tool.py
@@ -30,6 +30,7 @@ class Tool:
 	func: Callable[..., Any]
 	requires_confirmation: bool = False
 	confirm_prompt: Callable[[dict[str, Any]], str] | None = None
+	client_tool: bool = False
 
 	def __post_init__(self) -> None:
 		self._validated = validate_call(config=ConfigDict(arbitrary_types_allowed=True))(self.func)
@@ -55,6 +56,7 @@ def tool(
 	description: str | None = None,
 	requires_confirmation: bool = False,
 	confirm_prompt: Callable[[dict[str, Any]], str] | None = None,
+	client_tool: bool = False,
 ) -> Tool | Callable[[Callable[..., Any]], Tool]:
 	def wrap(f: Callable[..., Any]) -> Tool:
 		if not callable(f):
@@ -66,6 +68,7 @@ def tool(
 			func=f,
 			requires_confirmation=requires_confirmation,
 			confirm_prompt=confirm_prompt,
+			client_tool=client_tool,
 		)
 
 	return wrap(func) if func is not None else wrap

--- a/flow/tests/test_ai_agent.py
+++ b/flow/tests/test_ai_agent.py
@@ -721,6 +721,76 @@ class TestAgentConfirmation(UnitTestCase):
 		self.assertEqual([c.name for c in resumed.tool_calls], ["read_file", "write_file"])
 
 
+class TestAgentClientTools(UnitTestCase):
+	def _screen_tool(self):
+		calls: list[int] = []
+
+		@tool(client_tool=True)
+		def read_screen() -> dict:
+			"""Read the user's screen."""
+			calls.append(1)
+			raise AssertionError("client tool must never run on the server")
+
+		return read_screen, calls
+
+	def test_client_tool_pauses_without_executing(self):
+		read_screen, calls = self._screen_tool()
+		model = FakeModel([_tool_call("read_screen", {}, call_id="c1")])
+		agent = Agent(model=model, tools=[read_screen])
+
+		result = agent.run("what am I looking at?")
+
+		self.assertTrue(result.paused)
+		self.assertEqual(len(result.questions), 1)
+		self.assertTrue(result.questions[0].client_tool)
+		self.assertEqual(result.questions[0].key, "c1")
+		self.assertEqual(calls, [])  # never ran server-side
+		self.assertFalse([m for m in result.messages if m["role"] == "tool"])
+
+	def test_resume_feeds_browser_result_back_to_llm(self):
+		read_screen, _ = self._screen_tool()
+		agent = Agent(
+			model=FakeModel([_tool_call("read_screen", {}, call_id="c1")]),
+			tools=[read_screen],
+		)
+		paused = agent.run("what am I looking at?")
+
+		digest = {"view": "Form", "doctype": "Lead", "name": "CRM-LEAD-0001"}
+		agent.model = FakeModel([_final("You're on a Lead form.")])
+		result = agent.resume(paused.messages, {"c1": digest})
+
+		self.assertFalse(result.paused)
+		self.assertEqual(result.output, "You're on a Lead form.")
+		tool_msg = next(m for m in result.messages if m["role"] == "tool")
+		self.assertEqual(tool_msg["tool_call_id"], "c1")
+		self.assertEqual(json.loads(tool_msg["content"]), digest)
+
+	def test_unattended_run_cannot_call_client_tool(self):
+		read_screen, calls = self._screen_tool()
+		model = FakeModel([_tool_call("read_screen", {}, call_id="c1"), _final("done")])
+		agent = Agent(model=model, tools=[read_screen], auto_approve=True)
+
+		result = agent.run("what am I looking at?")
+
+		self.assertFalse(result.paused)
+		self.assertEqual(calls, [])
+		tool_msg = next(m for m in result.messages if m["role"] == "tool")
+		self.assertIn("error", json.loads(tool_msg["content"]))
+		self.assertEqual(result.output, "done")
+
+	def test_client_tool_pauses_in_streaming_run(self):
+		read_screen, _ = self._screen_tool()
+		model = FakeModel([_tool_call("read_screen", {}, call_id="c1")])
+		agent = Agent(model=model, tools=[read_screen])
+
+		done = list(agent.run("what am I looking at?", stream=True))[-1]
+
+		self.assertIsInstance(done, Done)
+		self.assertTrue(done.result.paused)
+		self.assertTrue(done.result.questions[0].client_tool)
+		self.assertEqual(done.result.questions[0].key, "c1")
+
+
 class TestQuestion(UnitTestCase):
 	def test_defaults_are_open_text_with_other(self):
 		q = Question(prompt="What subject line?")

--- a/flow/tests/test_ai_agent.py
+++ b/flow/tests/test_ai_agent.py
@@ -778,6 +778,42 @@ class TestAgentClientTools(UnitTestCase):
 		self.assertIn("error", json.loads(tool_msg["content"]))
 		self.assertEqual(result.output, "done")
 
+	def test_client_confirm_tool_pauses_with_options(self):
+		@tool(client_tool=True, requires_confirmation=True)
+		def act(action: str) -> dict:
+			"""Act on the open form."""
+			raise AssertionError("client tool must never run on the server")
+
+		model = FakeModel([_tool_call("act", {"action": "submit"}, call_id="c1")])
+		agent = Agent(model=model, tools=[act])
+
+		result = agent.run("submit this")
+
+		self.assertTrue(result.paused)
+		question = result.questions[0]
+		self.assertTrue(question.client_tool)
+		self.assertEqual(question.options, ["Approve", "Deny"])
+
+	def test_resume_feeds_client_confirm_result_not_server_run(self):
+		@tool(client_tool=True, requires_confirmation=True)
+		def act(action: str) -> dict:
+			"""Act on the open form."""
+			raise AssertionError("client tool must never run on the server")
+
+		agent = Agent(
+			model=FakeModel([_tool_call("act", {"action": "submit"}, call_id="c1")]),
+			tools=[act],
+		)
+		paused = agent.run("submit this")
+
+		outcome = {"docstatus": 1, "name": "SO-0001"}
+		agent.model = FakeModel([_final("Submitted SO-0001.")])
+		result = agent.resume(paused.messages, {"c1": outcome})
+
+		self.assertFalse(result.paused)
+		tool_msg = next(m for m in result.messages if m["role"] == "tool")
+		self.assertEqual(json.loads(tool_msg["content"]), outcome)
+
 	def test_client_tool_pauses_in_streaming_run(self):
 		read_screen, _ = self._screen_tool()
 		model = FakeModel([_tool_call("read_screen", {}, call_id="c1")])

--- a/flow/tests/test_ai_tool.py
+++ b/flow/tests/test_ai_tool.py
@@ -228,3 +228,29 @@ class TestSchemaPrimitives(UnitTestCase):
 		self.assertEqual(schema["properties"], {})
 		self.assertNotIn("required", schema)
 		self.assertFalse(schema["additionalProperties"])
+
+
+class TestBuildTool(UnitTestCase):
+	def _doc(self, **overrides):
+		from types import SimpleNamespace
+
+		fields = {"slug": "x", "description": "d", "requires_confirmation": 0, "client_tool": 0}
+		return SimpleNamespace(**{**fields, **overrides})
+
+	def test_imported_code_client_flag_wins_when_row_lags(self):
+		from flow.lib.resolver import _build_tool
+
+		built = _build_tool(self._doc(client_tool=0), {}, lambda: None, code_client_tool=True)
+		self.assertTrue(built.client_tool)
+
+	def test_row_client_flag_used_without_code_flag(self):
+		from flow.lib.resolver import _build_tool
+
+		built = _build_tool(self._doc(client_tool=1), {}, lambda: None)
+		self.assertTrue(built.client_tool)
+
+	def test_server_tool_stays_server(self):
+		from flow.lib.resolver import _build_tool
+
+		built = _build_tool(self._doc(client_tool=0), {}, lambda: None)
+		self.assertFalse(built.client_tool)

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -410,6 +410,24 @@ def navigate(
 navigate = tool(navigate, description=_NAVIGATE_DESCRIPTION, client_tool=True)
 
 
+_FILL_DESCRIPTION = """Fill the form the user currently has open: set field values on the record in \
+front of them. Operates on the open form only and never saves — the user reviews and commits. \
+Confirm the doctype and exact field names first (read_screen / describe).
+
+values maps {fieldname: value} for the main record — links, selects, dates, numbers, text. A child \
+table is a fieldname whose value is a list of row objects, e.g. {"items": [{"item_code": "A", \
+"qty": 2}]}; setting a table replaces its rows. Dependent fields and fetch_from fire automatically.
+
+Returns the resulting form state, including any field names that don't exist on the doctype."""
+
+
+def fill(values: dict[str, Any]) -> dict[str, Any]:
+	raise RuntimeError("fill runs in the browser, not on the server")
+
+
+fill = tool(fill, description=_FILL_DESCRIPTION, client_tool=True)
+
+
 BUILTIN_TOOLS: list[Tool] = [
 	find_doctypes,
 	describe,
@@ -422,6 +440,7 @@ BUILTIN_TOOLS: list[Tool] = [
 	execute,
 	read_screen,
 	navigate,
+	fill,
 ]
 
 

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -366,6 +366,23 @@ def run_action(
 	return result
 
 
+_READ_SCREEN_DESCRIPTION = """See what the user is currently looking at in the Desk: the active \
+route/view and, for an open form, its doctype, record name, unsaved-changes and submission state, \
+the filled field values, and any still-empty mandatory fields.
+
+Use it to ground yourself whenever the user refers to what is on their screen ("this record", \
+"this form", "why can't I submit this"). Runs in the user's browser and returns a JSON digest."""
+
+
+def read_screen() -> dict[str, Any]:
+	# Client tool: executed in the browser (see frontend/src/lib/clientTools.js), never on the
+	# server. The signature only defines the (empty) argument schema the model sees.
+	raise RuntimeError("read_screen runs in the browser, not on the server")
+
+
+read_screen = tool(read_screen, description=_READ_SCREEN_DESCRIPTION, client_tool=True)
+
+
 BUILTIN_TOOLS: list[Tool] = [
 	find_doctypes,
 	describe,
@@ -376,6 +393,7 @@ BUILTIN_TOOLS: list[Tool] = [
 	delete,
 	run_action,
 	execute,
+	read_screen,
 ]
 
 
@@ -392,6 +410,7 @@ def sync_builtin_tools() -> None:
 					"import_path": import_path,
 					"description": builtin.description,
 					"requires_confirmation": int(builtin.requires_confirmation),
+					"client_tool": int(builtin.client_tool),
 					"is_system_generated": 1,
 				},
 			)
@@ -406,5 +425,6 @@ def sync_builtin_tools() -> None:
 					"description": builtin.description,
 					"is_system_generated": 1,
 					"requires_confirmation": int(builtin.requires_confirmation),
+					"client_tool": int(builtin.client_tool),
 				}
 			).insert(ignore_permissions=True)

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Literal
 
 import frappe
 from frappe import _
@@ -383,6 +383,33 @@ def read_screen() -> dict[str, Any]:
 read_screen = tool(read_screen, description=_READ_SCREEN_DESCRIPTION, client_tool=True)
 
 
+_NAVIGATE_DESCRIPTION = """Take the user to a screen in the Desk. Navigation only — never creates \
+or changes data.
+
+- view="form": open an existing record (needs doctype and name).
+- view="new": open a blank new-record form (needs doctype).
+- view="list": open a doctype's list (needs doctype); pass filters to narrow it, e.g. \
+{"status": "Open"} or {"grand_total": [">", 1000]}.
+- view="report": open a query report (needs report); pass filters as its filter values.
+- view="workspace": open a workspace (needs workspace).
+
+Resolve exact doctype/report names with find_doctypes first. Returns the route navigated to."""
+
+
+def navigate(
+	view: Literal["form", "new", "list", "report", "workspace"],
+	doctype: str | None = None,
+	name: str | None = None,
+	report: str | None = None,
+	workspace: str | None = None,
+	filters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+	raise RuntimeError("navigate runs in the browser, not on the server")
+
+
+navigate = tool(navigate, description=_NAVIGATE_DESCRIPTION, client_tool=True)
+
+
 BUILTIN_TOOLS: list[Tool] = [
 	find_doctypes,
 	describe,
@@ -394,6 +421,7 @@ BUILTIN_TOOLS: list[Tool] = [
 	run_action,
 	execute,
 	read_screen,
+	navigate,
 ]
 
 

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -428,6 +428,31 @@ def fill(values: dict[str, Any]) -> dict[str, Any]:
 fill = tool(fill, description=_FILL_DESCRIPTION, client_tool=True)
 
 
+_ACT_DESCRIPTION = """Act on the form the user currently has open. Operates on the open form only.
+
+action is one of:
+- "save": save the current changes (creates the record if it is new).
+- "submit": submit the document.
+- "cancel": cancel a submitted document.
+- a workflow transition name (e.g. "Approve", "Reject") — get valid ones from describe(doctype, name).
+
+The user confirms before it runs. Returns the resulting form state (record name, docstatus, whether \
+it still has unsaved changes)."""
+
+
+def act(action: str) -> dict[str, Any]:
+	raise RuntimeError("act runs in the browser, not on the server")
+
+
+act = tool(
+	act,
+	description=_ACT_DESCRIPTION,
+	client_tool=True,
+	requires_confirmation=True,
+	confirm_prompt=lambda args: f"{str(args.get('action', 'act')).title()} the open record?",
+)
+
+
 BUILTIN_TOOLS: list[Tool] = [
 	find_doctypes,
 	describe,
@@ -441,6 +466,7 @@ BUILTIN_TOOLS: list[Tool] = [
 	read_screen,
 	navigate,
 	fill,
+	act,
 ]
 
 

--- a/frontend/src/components/AssistantMessage.vue
+++ b/frontend/src/components/AssistantMessage.vue
@@ -9,7 +9,11 @@ import { useStore } from "@/store";
 const props = defineProps({ message: { type: Object, required: true } });
 const { answerQuestion, toolApproval } = useStore();
 
-const questionByKey = computed(() => new Map(props.message.questions.map((q) => [q.key, q])));
+// Client directives resolve automatically in the browser — they render as normal tool
+// activity, never as a confirmation card, so they're excluded from the question map.
+const questionByKey = computed(
+	() => new Map(props.message.questions.filter((q) => !q.client_tool).map((q) => [q.key, q]))
+);
 
 // A confirmation tool (per the agent's tool map), or one that has/had a question.
 function isApproval(part) {

--- a/frontend/src/components/AssistantMessage.vue
+++ b/frontend/src/components/AssistantMessage.vue
@@ -9,10 +9,16 @@ import { useStore } from "@/store";
 const props = defineProps({ message: { type: Object, required: true } });
 const { answerQuestion, toolApproval } = useStore();
 
-// Client directives resolve automatically in the browser — they render as normal tool
-// activity, never as a confirmation card, so they're excluded from the question map.
+// Auto-running client directives (no options) resolve in the browser and render as normal tool
+// activity, so they're excluded from the question map. Client directives that need confirmation
+// carry Approve/Deny options and render as a card, like the server-side write tools.
 const questionByKey = computed(
-	() => new Map(props.message.questions.filter((q) => !q.client_tool).map((q) => [q.key, q]))
+	() =>
+		new Map(
+			props.message.questions
+				.filter((q) => !q.client_tool || q.options?.length)
+				.map((q) => [q.key, q])
+		)
 );
 
 // A confirmation tool (per the agent's tool map), or one that has/had a question.

--- a/frontend/src/lib/clientTools.js
+++ b/frontend/src/lib/clientTools.js
@@ -14,12 +14,42 @@ const LAYOUT_FIELDTYPES = new Set([
 
 const registry = {
 	read_screen: readScreen,
+	navigate: navigate,
 };
 
 export async function runClientTool(name, args = {}) {
 	const fn = registry[name];
 	if (!fn) throw new Error(`Unknown client tool: ${name}`);
 	return await fn(args);
+}
+
+async function navigate({ view, doctype, name, report, workspace, filters }) {
+	if (view === "new") {
+		if (!doctype) throw new Error("view 'new' needs a doctype");
+		await frappe.new_doc(doctype);
+		return { navigated: true, route: frappe.get_route() };
+	}
+
+	let route;
+	if (view === "form") {
+		if (!doctype || !name) throw new Error("view 'form' needs a doctype and name");
+		route = ["Form", doctype, name];
+	} else if (view === "list") {
+		if (!doctype) throw new Error("view 'list' needs a doctype");
+		route = ["List", doctype];
+	} else if (view === "report") {
+		if (!report) throw new Error("view 'report' needs a report");
+		route = ["query-report", report];
+	} else if (view === "workspace") {
+		if (!workspace) throw new Error("view 'workspace' needs a workspace");
+		route = ["Workspaces", workspace];
+	} else {
+		throw new Error(`Unknown view: ${view}`);
+	}
+
+	if (filters && (view === "list" || view === "report")) frappe.route_options = filters;
+	await frappe.set_route(route);
+	return { navigated: true, route };
 }
 
 function readScreen() {

--- a/frontend/src/lib/clientTools.js
+++ b/frontend/src/lib/clientTools.js
@@ -16,6 +16,7 @@ const registry = {
 	read_screen: readScreen,
 	navigate: navigate,
 	fill: fill,
+	act: act,
 };
 
 export async function runClientTool(name, args = {}) {
@@ -94,6 +95,25 @@ async function fill({ values }) {
 	return state;
 }
 
+async function act({ action }) {
+	const frm = window.cur_frm;
+	if (!frm?.doc) throw new Error("no form is open to act on");
+	if (!action) throw new Error("action is required");
+
+	const lifecycle = { save: "Save", submit: "Submit", cancel: "Cancel" };
+	if (lifecycle[action]) {
+		await frm.save(lifecycle[action]);
+	} else {
+		const doc = await frappe.xcall("frappe.model.workflow.apply_workflow", {
+			doc: frm.doc,
+			action,
+		});
+		frappe.model.sync(doc);
+		await frm.refresh();
+	}
+	return formState(frm);
+}
+
 function readScreen() {
 	const route = typeof frappe?.get_route === "function" ? frappe.get_route() : [];
 	const view = route[0] || "";
@@ -141,6 +161,7 @@ function formState(frm) {
 		name: frm.doc.name,
 		is_new: Boolean(frm.is_new()),
 		is_dirty: Boolean(frm.is_dirty()),
+		is_submittable: Boolean(frm.meta.is_submittable),
 		docstatus: frm.doc.docstatus,
 		values,
 		missing_mandatory: missingMandatory,

--- a/frontend/src/lib/clientTools.js
+++ b/frontend/src/lib/clientTools.js
@@ -1,0 +1,76 @@
+// Client tools run in the Desk window (the Flow panel is injected there) and return a
+// JSON-serializable digest that flows back to the agent as the tool's result. The agent
+// supplies only the tool name and arguments — it can never execute arbitrary browser code.
+
+const LAYOUT_FIELDTYPES = new Set([
+	"Section Break",
+	"Column Break",
+	"Tab Break",
+	"HTML",
+	"Heading",
+	"Fold",
+	"Button",
+]);
+
+const registry = {
+	read_screen: readScreen,
+};
+
+export async function runClientTool(name, args = {}) {
+	const fn = registry[name];
+	if (!fn) throw new Error(`Unknown client tool: ${name}`);
+	return await fn(args);
+}
+
+function readScreen() {
+	const route = typeof frappe?.get_route === "function" ? frappe.get_route() : [];
+	const view = route[0] || "";
+	const digest = { view, route };
+
+	const frm = window.cur_frm;
+	if (view === "Form" && frm?.doc) return { ...digest, ...formDigest(frm) };
+
+	const list = window.cur_list;
+	if (view === "List" && list) {
+		digest.doctype = list.doctype;
+		digest.list_view = route[2] || "List";
+		digest.filters =
+			typeof list.get_filters_for_args === "function" ? list.get_filters_for_args() : [];
+		const selected =
+			typeof list.get_checked_items === "function" ? list.get_checked_items(true) : [];
+		if (selected.length) digest.selected = selected;
+		return digest;
+	}
+
+	const report = frappe?.query_report;
+	if (view === "query-report" && report) {
+		digest.report = report.report_name;
+		digest.filters =
+			typeof report.get_filter_values === "function" ? report.get_filter_values() : {};
+		return digest;
+	}
+
+	if (route[1]) digest.doctype = route[1];
+	return digest;
+}
+
+function formDigest(frm) {
+	const values = {};
+	const missingMandatory = [];
+	for (const df of frm.meta.fields) {
+		if (LAYOUT_FIELDTYPES.has(df.fieldtype)) continue;
+		const value = frm.doc[df.fieldname];
+		const empty = value === undefined || value === null || value === "";
+		if (df.reqd && empty) missingMandatory.push(df.fieldname);
+		if (!empty && typeof value !== "object") values[df.fieldname] = value;
+	}
+	return {
+		doctype: frm.doctype,
+		name: frm.doc.name,
+		is_new: Boolean(frm.is_new()),
+		is_dirty: Boolean(frm.is_dirty()),
+		docstatus: frm.doc.docstatus,
+		values,
+		missing_mandatory: missingMandatory,
+	};
+}

--- a/frontend/src/lib/clientTools.js
+++ b/frontend/src/lib/clientTools.js
@@ -104,6 +104,9 @@ async function act({ action }) {
 	if (lifecycle[action]) {
 		await frm.save(lifecycle[action]);
 	} else {
+		// A workflow transition saves the doc server-side; refuse on a dirty form so unsaved
+		// edits aren't persisted implicitly — the agent must save (a separate, confirmed act) first.
+		if (frm.is_dirty()) throw new Error("save the form before applying a workflow action");
 		const doc = await frappe.xcall("frappe.model.workflow.apply_workflow", {
 			doc: frm.doc,
 			action,

--- a/frontend/src/lib/clientTools.js
+++ b/frontend/src/lib/clientTools.js
@@ -1,6 +1,6 @@
 // Client tools run in the Desk window (the Flow panel is injected there) and return a
-// JSON-serializable digest that flows back to the agent as the tool's result. The agent
-// supplies only the tool name and arguments — it can never execute arbitrary browser code.
+// JSON-serializable result that flows back to the agent. The agent supplies only the tool
+// name and arguments — it can never execute arbitrary browser code.
 
 const LAYOUT_FIELDTYPES = new Set([
 	"Section Break",
@@ -15,6 +15,7 @@ const LAYOUT_FIELDTYPES = new Set([
 const registry = {
 	read_screen: readScreen,
 	navigate: navigate,
+	fill: fill,
 };
 
 export async function runClientTool(name, args = {}) {
@@ -26,8 +27,8 @@ export async function runClientTool(name, args = {}) {
 async function navigate({ view, doctype, name, report, workspace, filters }) {
 	if (view === "new") {
 		if (!doctype) throw new Error("view 'new' needs a doctype");
-		await frappe.new_doc(doctype);
-		return { navigated: true, route: frappe.get_route() };
+		const newName = await openNewForm(doctype);
+		return { navigated: true, route: ["Form", doctype, newName] };
 	}
 
 	let route;
@@ -52,39 +53,80 @@ async function navigate({ view, doctype, name, report, workspace, filters }) {
 	return { navigated: true, route };
 }
 
+// Open a blank *full* form, bypassing the Quick Entry modal that frappe.new_doc opens for some
+// doctypes
+function openNewForm(doctype) {
+	return new Promise((resolve, reject) => {
+		frappe.model.with_doctype(doctype, () => {
+			try {
+				const doc = frappe.model.get_new_doc(doctype);
+				frappe.set_route("Form", doctype, doc.name).then(() => resolve(doc.name));
+			} catch (e) {
+				reject(e);
+			}
+		});
+	});
+}
+
+async function fill({ values }) {
+	const frm = window.cur_frm;
+	if (!frm?.doc) throw new Error("no form is open to fill");
+	if (!values || typeof values !== "object") {
+		throw new Error("values must be an object of {fieldname: value}");
+	}
+
+	const known = new Set(frm.meta.fields.map((df) => df.fieldname));
+	const toSet = {};
+	const errors = {};
+	for (const [field, value] of Object.entries(values)) {
+		if (known.has(field)) toSet[field] = value;
+		else errors[field] = "no such field on this doctype";
+	}
+
+	const fields = Object.keys(toSet);
+	if (fields.length) {
+		await frm.set_value(toSet);
+		if (typeof frm.scroll_to_field === "function") frm.scroll_to_field(fields[0]);
+	}
+
+	const state = formState(frm);
+	if (Object.keys(errors).length) state.errors = errors;
+	return state;
+}
+
 function readScreen() {
 	const route = typeof frappe?.get_route === "function" ? frappe.get_route() : [];
 	const view = route[0] || "";
-	const digest = { view, route };
+	const screen = { view, route };
 
 	const frm = window.cur_frm;
-	if (view === "Form" && frm?.doc) return { ...digest, ...formDigest(frm) };
+	if (view === "Form" && frm?.doc) return { ...screen, ...formState(frm) };
 
 	const list = window.cur_list;
 	if (view === "List" && list) {
-		digest.doctype = list.doctype;
-		digest.list_view = route[2] || "List";
-		digest.filters =
+		screen.doctype = list.doctype;
+		screen.list_view = route[2] || "List";
+		screen.filters =
 			typeof list.get_filters_for_args === "function" ? list.get_filters_for_args() : [];
 		const selected =
 			typeof list.get_checked_items === "function" ? list.get_checked_items(true) : [];
-		if (selected.length) digest.selected = selected;
-		return digest;
+		if (selected.length) screen.selected = selected;
+		return screen;
 	}
 
 	const report = frappe?.query_report;
 	if (view === "query-report" && report) {
-		digest.report = report.report_name;
-		digest.filters =
+		screen.report = report.report_name;
+		screen.filters =
 			typeof report.get_filter_values === "function" ? report.get_filter_values() : {};
-		return digest;
+		return screen;
 	}
 
-	if (route[1]) digest.doctype = route[1];
-	return digest;
+	if (route[1]) screen.doctype = route[1];
+	return screen;
 }
 
-function formDigest(frm) {
+function formState(frm) {
 	const values = {};
 	const missingMandatory = [];
 	for (const df of frm.meta.fields) {

--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -44,6 +44,7 @@ const LABELS = {
 	read_screen: "Reading the screen",
 	navigate: "Navigating",
 	fill: "Filling the form",
+	act: "Acting on the record",
 };
 
 export function toolLabel(name) {
@@ -154,5 +155,10 @@ export function confirmTitle(name, args) {
 			doctype ? `${count(a.names)} ${doctype}` : __("records"),
 		]);
 	else if (name === "execute") title = __("Run Python code");
-	return { title: title || toolLabel(name), danger: name === "delete" };
+	else if (name === "act" && typeof a.action === "string" && a.action)
+		title = __("{0} the open record", [humanize(a.action)]);
+	return {
+		title: title || toolLabel(name),
+		danger: name === "delete" || (name === "act" && a.action === "cancel"),
+	};
 }

--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -41,6 +41,7 @@ const LABELS = {
 	update: "Updating Records",
 	delete: "Deleting Records",
 	run_action: "Running Document Actions",
+	read_screen: "Reading the screen",
 };
 
 export function toolLabel(name) {

--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -43,6 +43,7 @@ const LABELS = {
 	run_action: "Running Document Actions",
 	read_screen: "Reading the screen",
 	navigate: "Navigating",
+	fill: "Filling the form",
 };
 
 export function toolLabel(name) {

--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -42,6 +42,7 @@ const LABELS = {
 	delete: "Deleting Records",
 	run_action: "Running Document Actions",
 	read_screen: "Reading the screen",
+	navigate: "Navigating",
 };
 
 export function toolLabel(name) {

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,7 +1,8 @@
 import { ref, computed } from "vue";
 import * as api from "@/api/client";
 import { startRun, resumeRun } from "@/api/stream";
-import { normalizeToolName } from "@/lib/toolMeta";
+import { runClientTool } from "@/lib/clientTools";
+import { normalizeToolName, parseArgs } from "@/lib/toolMeta";
 import { __ } from "@/lib/translate";
 
 // Module-singleton store: one panel instance, one source of truth. Components
@@ -235,6 +236,21 @@ async function restorePausedRun(session) {
 	last.runName = runs[0].name;
 	runName.value = runs[0].name;
 	requestScroll();
+
+	// A reload landing mid client-pause leaves pending client directives; run them so the
+	// turn isn't stuck. Human questions restore as cards (answered via answerQuestion).
+	if (last.questions.some((q) => q.client_tool)) {
+		sending.value = true;
+		try {
+			await settleClientCalls(last);
+		} catch (e) {
+			failMessage(last, e);
+		} finally {
+			sending.value = false;
+			requestScroll();
+			focusTick.value++;
+		}
+	}
 }
 
 // ── sending / streaming ────────────────────────────────────────────────────────
@@ -263,6 +279,7 @@ async function send(text) {
 			},
 			(event) => handleEvent(event, assistant)
 		);
+		await settleClientCalls(assistant);
 	} catch (e) {
 		failMessage(assistant, e);
 	} finally {
@@ -285,12 +302,46 @@ async function resume(answers, pausedMsg) {
 
 	try {
 		await resumeRun({ run_name: rn, answers }, (event) => handleEvent(event, pausedMsg));
+		await settleClientCalls(pausedMsg);
 	} catch (e) {
 		failMessage(pausedMsg, e);
 	} finally {
 		sending.value = false;
 		requestScroll();
 		focusTick.value++;
+	}
+}
+
+// A run pauses on a client directive (a client tool the agent called). The panel runs it in
+// the Desk window and resumes with the result. Loops so chained client calls settle within
+// one turn; returns early when a human question remains — the user answers it (answerQuestion),
+// which resumes the run. Runs inside the caller's `sending` envelope, so no re-entrancy.
+async function settleClientCalls(msg) {
+	for (;;) {
+		const pending = msg.questions.filter((q) => q.client_tool && q._answer === undefined);
+		if (!pending.length) return;
+
+		for (const q of pending) {
+			const part = msg.parts.find((p) => p.type === "tool" && p.id === q.key);
+			q._answer = await runClientDirective(part);
+		}
+		if (msg.questions.some((q) => q._answer === undefined)) return;
+
+		const answers = {};
+		msg.questions.forEach((q) => (answers[q.key] = q._answer));
+		msg.questions = [];
+		msg.pending = true;
+		await resumeRun({ run_name: msg.runName || runName.value, answers }, (event) =>
+			handleEvent(event, msg)
+		);
+	}
+}
+
+async function runClientDirective(part) {
+	try {
+		return await runClientTool(part?.name, parseArgs(part?.arguments));
+	} catch (e) {
+		return { error: e?.message || String(e) };
 	}
 }
 

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -314,11 +314,14 @@ async function resume(answers, pausedMsg) {
 
 // A run pauses on a client directive (a client tool the agent called). The panel runs it in
 // the Desk window and resumes with the result. Loops so chained client calls settle within
-// one turn; returns early when a human question remains — the user answers it (answerQuestion),
-// which resumes the run. Runs inside the caller's `sending` envelope, so no re-entrancy.
+// one turn; returns early when a question needing the user remains — a human question or a
+// client directive that requires confirmation (it carries options and renders as a card, then
+// answerQuestion runs it). Runs inside the caller's `sending` envelope, so no re-entrancy.
 async function settleClientCalls(msg) {
 	for (;;) {
-		const pending = msg.questions.filter((q) => q.client_tool && q._answer === undefined);
+		const pending = msg.questions.filter(
+			(q) => q.client_tool && q._answer === undefined && !q.options?.length
+		);
 		if (!pending.length) return;
 
 		for (const q of pending) {
@@ -345,16 +348,25 @@ async function runClientDirective(part) {
 	}
 }
 
-// Records one answer and stamps the tool's approval state; once every question
-// on the paused message is answered, resumes the run with all answers at once.
-function answerQuestion(msg, question, answer) {
+// Records one answer and stamps the tool's approval state; once every question on the paused
+// message is answered, resumes the run with all answers at once. For a client tool the answer
+// is the browser result: approving runs it in the Desk, denying/redirecting feed that back.
+async function answerQuestion(msg, question, answer) {
 	const a = (answer || "").trim();
 	if (!a || !msg) return;
 
-	question._answer = a;
 	const tool = msg.parts.find((p) => p.type === "tool" && p.id === question.key);
 	if (tool)
 		tool.approval = a === "Approve" ? "approved" : a === "Deny" ? "denied" : "redirected";
+
+	if (question.client_tool) {
+		if (a === "Approve") question._answer = await runClientDirective(tool);
+		else if (a === "Deny")
+			question._answer = { denied: true, message: "User denied this action." };
+		else question._answer = { redirect: true, user_feedback: a };
+	} else {
+		question._answer = a;
+	}
 
 	if (msg.questions.some((q) => q._answer === undefined)) return;
 


### PR DESCRIPTION
Adds **client tools** — tools the panel agent runs in the browser to operate the live Desk. The run pauses on a client tool, the panel executes it against the Desk window, and resumes with the result (reusing the existing pause/resume machinery). Excluded from trigger runs; everything runs in the user's own session.

Tools:
- **read_screen** — current route + open form/list/report state.
- **navigate** — open a form / new form / filtered list / report / workspace.
- **fill** — set field values on the open form; never saves.
- **act** — save / submit / cancel / workflow transition, gated by the inline confirmation card.