### PR TITLE
fix: recover from malformed tool-call arguments

### DIFF
--- a/flow/flow/doctype/flow_run/flow_run.py
+++ b/flow/flow/doctype/flow_run/flow_run.py
@@ -93,7 +93,9 @@ class FlowRun(Document):
 		self.status = _status_from_result(result)
 		self.iterations = (self.iterations or 0) + result.iterations
 		self.output = result.output
-		self.tool_calls = _dump_json([asdict(call) for call in result.tool_calls])
+		self.tool_calls = _dump_json(
+			[{"id": c.id, "name": c.name, "arguments": c.arguments} for c in result.tool_calls]
+		)
 		self.questions = _dump_json([asdict(q) for q in result.questions]) if result.paused else None
 		self.usage = _dump_json(_merge_usage(self.usage, result.usage))
 		if self.status != "Failed":

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -354,6 +354,8 @@ class Agent:
 	def _invoke(self, call: ToolCall) -> Any:
 		"""Run a tool and return its raw result. A Question (returned or synthesized for
 		`requires_confirmation` tools) signals a pause."""
+		if call.error:
+			return json.dumps({"error": call.error})
 		tool = self._tools_by_name.get(call.name)
 		if tool is None:
 			return json.dumps({"error": f"Unknown tool: {call.name!r}"})

--- a/flow/lib/model.py
+++ b/flow/lib/model.py
@@ -18,6 +18,9 @@ class ToolCall:
 	id: str
 	name: str
 	arguments: dict[str, Any]
+	# Set when the model emitted unparseable arguments; the agent feeds this back so it can retry
+	# instead of the whole run failing.
+	error: str | None = None
 
 
 @dataclass
@@ -184,15 +187,33 @@ def _finalize_tool_calls(acc: dict[int, dict[str, str]]) -> list[ToolCall]:
 		slot = acc[index]
 		if not slot["id"] and not slot["name"]:
 			continue
-		raw_args = slot["arguments"] or ""
-		try:
-			arguments = json.loads(raw_args) if raw_args else {}
-		except (TypeError, ValueError) as e:
-			raise ValueError(f"Tool call {slot['name']!r} returned invalid JSON arguments") from e
-		if not isinstance(arguments, dict):
-			raise ValueError(f"Tool call {slot['name']!r} arguments must be a JSON object")
-		calls.append(ToolCall(id=slot["id"], name=slot["name"], arguments=arguments))
+		calls.append(_build_tool_call(slot["id"], slot["name"], slot["arguments"]))
 	return calls
+
+
+def _build_tool_call(call_id: str, name: str, raw_args: str) -> ToolCall:
+	"""Parse a tool call's raw arguments. Malformed arguments become a `ToolCall.error` the agent
+	feeds back to the model to retry, rather than an exception that fails the whole run."""
+	raw_args = raw_args or ""
+	if not raw_args:
+		return ToolCall(id=call_id, name=name, arguments={})
+	try:
+		arguments = json.loads(raw_args)
+	except (TypeError, ValueError):
+		return ToolCall(
+			id=call_id,
+			name=name,
+			arguments={},
+			error=f"Invalid JSON in arguments for {name!r}: {raw_args[:200]}. Resend the call with valid JSON.",
+		)
+	if not isinstance(arguments, dict):
+		return ToolCall(
+			id=call_id,
+			name=name,
+			arguments={},
+			error=f"Arguments for {name!r} must be a JSON object, got: {raw_args[:200]}.",
+		)
+	return ToolCall(id=call_id, name=name, arguments=arguments)
 
 
 def _normalize(response: Any) -> ChatResponse:
@@ -204,13 +225,7 @@ def _normalize(response: Any) -> ChatResponse:
 		function = getattr(raw_call, "function", None) or {}
 		name = _attr(function, "name", "")
 		raw_args = _attr(function, "arguments", "") or ""
-		try:
-			arguments = json.loads(raw_args) if raw_args else {}
-		except (TypeError, ValueError) as e:
-			raise ValueError(f"Tool call {name!r} returned invalid JSON arguments") from e
-		if not isinstance(arguments, dict):
-			raise ValueError(f"Tool call {name!r} arguments must be a JSON object")
-		tool_calls.append(ToolCall(id=_attr(raw_call, "id", ""), name=name, arguments=arguments))
+		tool_calls.append(_build_tool_call(_attr(raw_call, "id", ""), name, raw_args))
 
 	usage_obj = getattr(response, "usage", None)
 	usage = {

--- a/flow/tests/test_ai_agent.py
+++ b/flow/tests/test_ai_agent.py
@@ -738,3 +738,44 @@ class TestQuestion(UnitTestCase):
 		self.assertEqual(q.options, ["Go ahead", "Only the 2 oldest"])
 		self.assertTrue(q.allow_other)
 		self.assertEqual(q.key, "c1")
+
+
+class TestToolCallParsing(UnitTestCase):
+	def test_invalid_json_becomes_error_not_raise(self):
+		from flow.lib.model import _build_tool_call
+
+		call = _build_tool_call("c1", "read", "{not json")
+		self.assertEqual(call.arguments, {})
+		self.assertIn("Invalid JSON", call.error)
+
+	def test_non_object_json_is_error(self):
+		from flow.lib.model import _build_tool_call
+
+		call = _build_tool_call("c1", "read", "[1, 2]")
+		self.assertIn("must be a JSON object", call.error)
+
+	def test_valid_json_parses_without_error(self):
+		from flow.lib.model import _build_tool_call
+
+		call = _build_tool_call("c1", "read", '{"doctype": "User"}')
+		self.assertIsNone(call.error)
+		self.assertEqual(call.arguments, {"doctype": "User"})
+
+
+class TestAgentMalformedToolCall(UnitTestCase):
+	def test_parse_error_feeds_back_and_run_continues(self):
+		bad = ChatResponse(
+			content=None,
+			tool_calls=[
+				ToolCall(id="c1", name="read", arguments={}, error="Invalid JSON in arguments for 'read'.")
+			],
+		)
+		model = FakeModel([bad, _final("recovered")])
+		agent = Agent(model=model)
+
+		result = agent.run("read something")
+
+		self.assertFalse(result.paused)
+		self.assertEqual(result.output, "recovered")
+		tool_msg = next(m for m in result.messages if m["role"] == "tool")
+		self.assertIn("Invalid JSON", json.loads(tool_msg["content"])["error"])

--- a/flow/tests/test_ai_model.py
+++ b/flow/tests/test_ai_model.py
@@ -126,7 +126,7 @@ class TestModel(UnitTestCase):
 		self.assertEqual(resp.finish_reason, "tool_calls")
 
 	@patch("litellm.completion")
-	def test_chat_rejects_invalid_tool_arguments(self, mock_completion):
+	def test_chat_returns_error_for_invalid_tool_arguments(self, mock_completion):
 		raw_call = SimpleNamespace(
 			id="call_bad",
 			function=SimpleNamespace(name="broken", arguments="{not json"),
@@ -134,8 +134,11 @@ class TestModel(UnitTestCase):
 		mock_completion.return_value = _fake_response(tool_calls=[raw_call])
 
 		m = Model(model_id="openai/gpt-4.1", api_key="sk-test")
-		with self.assertRaises(ValueError):
-			m.chat([{"role": "user", "content": "hi"}])
+		resp = m.chat([{"role": "user", "content": "hi"}])
+
+		call = resp.tool_calls[0]
+		self.assertEqual(call.arguments, {})
+		self.assertIn("Invalid JSON", call.error)
 
 	@patch("litellm.completion")
 	def test_chat_stream_yields_text_deltas_and_assembles_response(self, mock_completion):
@@ -197,7 +200,7 @@ class TestModel(UnitTestCase):
 		self.assertEqual(kwargs["stream_options"], {"include_usage": True})
 
 	@patch("litellm.completion")
-	def test_chat_stream_rejects_invalid_tool_arguments(self, mock_completion):
+	def test_chat_stream_returns_error_for_invalid_tool_arguments(self, mock_completion):
 		mock_completion.return_value = iter(
 			[
 				_stream_chunk(tool_calls=[_tc_delta(id="c1", name="boom", arguments="{not json")]),
@@ -206,8 +209,11 @@ class TestModel(UnitTestCase):
 		)
 
 		m = Model(model_id="openai/gpt-4.1", api_key="sk-test")
-		with self.assertRaises(ValueError):
-			_drain(m.chat([{"role": "user", "content": "hi"}], stream=True))
+		_yielded, response = _drain(m.chat([{"role": "user", "content": "hi"}], stream=True))
+
+		call = response.tool_calls[0]
+		self.assertEqual(call.arguments, {})
+		self.assertIn("Invalid JSON", call.error)
 
 	@patch("litellm.completion")
 	def test_chat_forwards_params_tools_and_base_url(self, mock_completion):


### PR DESCRIPTION
A model that emits invalid JSON in a tool call's arguments crashed the whole run (`_normalize`/`_finalize_tool_calls` raised `ValueError`, which failed the Flow Run). Weaker models (e.g. GLM) hit this.

Now a malformed tool call becomes an error result fed back to the model — same as the existing unknown-tool / tool-exception handling — so it can retry instead of the run dying. `ToolCall` gains an optional `error`; a shared `_build_tool_call` replaces the two raise sites; `agent._invoke` returns the error as the tool result.