### PR TITLE
fix: report dynamically-mandatory fields in read_screen

### DIFF
--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -384,10 +384,12 @@ def run_action(
 
 _READ_SCREEN_DESCRIPTION = """See what the user is currently looking at in the Desk: the active \
 route/view and, for an open form, its doctype, record name, unsaved-changes and submission state, \
-the filled field values, and any still-empty mandatory fields.
+the filled field values, and any still-empty mandatory fields (including ones made mandatory \
+dynamically).
 
 Use it to ground yourself whenever the user refers to what is on their screen ("this record", \
-"this form", "why can't I submit this"). Runs in the user's browser and returns a JSON digest."""
+"this form", "why can't I submit this"), and after filling to confirm no mandatory field is left \
+blank. Runs in the user's browser and returns a JSON digest."""
 
 
 def read_screen() -> dict[str, Any]:

--- a/frontend/src/lib/clientTools.js
+++ b/frontend/src/lib/clientTools.js
@@ -154,9 +154,12 @@ function formState(frm) {
 	const missingMandatory = [];
 	for (const df of frm.meta.fields) {
 		if (LAYOUT_FIELDTYPES.has(df.fieldtype)) continue;
+		// Live docfield reflects dynamic mandatory (toggle_reqd / mandatory_depends_on); the
+		// static meta field does not.
+		const live = frappe.meta.get_docfield(frm.doctype, df.fieldname, frm.doc.name) || df;
 		const value = frm.doc[df.fieldname];
 		const empty = value === undefined || value === null || value === "";
-		if (df.reqd && empty) missingMandatory.push(df.fieldname);
+		if (live.reqd && empty) missingMandatory.push(df.fieldname);
 		if (!empty && typeof value !== "object") values[df.fieldname] = value;
 	}
 	return {


### PR DESCRIPTION
`read_screen`/`fill` reported `missing_mandatory` from the static `frm.meta.fields`, so fields made mandatory at runtime (via `toggle_reqd` or `mandatory_depends_on` — e.g. Expense Claim's `expense_approver`) were never flagged. The model then thought all required fields were filled and stopped early.

Now `formState` reads the live docfield (`frappe.meta.get_docfield(doctype, fieldname, docname)`), which reflects dynamic mandatory state. `read_screen`'s description is updated to note this and to re-check after filling.