### PR TITLE
fix: correct DocType casing in read tool label

### DIFF
--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -34,7 +34,7 @@ export function humanize(name) {
 const LABELS = {
 	find_doctypes: "Finding relevant DocTypes",
 	describe: "Reading DocType Meta",
-	read: "Reading Doctype Records",
+	read: "Reading DocType Records",
 	search_knowledge: "Searching Knowledge",
 	execute: "Executing",
 	create: "Creating Records",


### PR DESCRIPTION
Align the `read` label with its siblings: "Reading Doctype Records" → "Reading DocType Records".