### PR TITLE
feat: stop response

### DIFF
--- a/flow/api/__init__.py
+++ b/flow/api/__init__.py
@@ -1,4 +1,18 @@
 # Re-exported so whitelisted endpoints stay reachable at flow.api.<name>.
-from flow.api.api import attach_file, get_agent_tools, recover_session, resume_run, start_run
+from flow.api.api import (
+	attach_file,
+	get_agent_tools,
+	recover_session,
+	resume_run,
+	start_run,
+	stop_run,
+)
 
-__all__ = ["attach_file", "get_agent_tools", "recover_session", "resume_run", "start_run"]
+__all__ = [
+	"attach_file",
+	"get_agent_tools",
+	"recover_session",
+	"resume_run",
+	"start_run",
+	"stop_run",
+]

--- a/flow/api/api.py
+++ b/flow/api/api.py
@@ -63,6 +63,22 @@ def resume_run(
 
 
 @frappe.whitelist()
+def stop_run(run_name: str) -> dict[str, str]:
+	"""Stop a run at the user's request: terminate a Paused run so the agent won't continue,
+	or finalize a Running one whose SSE stream the client has aborted."""
+	from flow.lib.session import assert_run_owner
+
+	if not isinstance(run_name, str) or not run_name.strip():
+		frappe.throw(_("Run is required."), title=_("Invalid Run"))
+
+	run = frappe.get_doc("Flow Run", run_name.strip())
+	assert_run_owner(run)
+	if run.status not in ("Completed", "Failed"):
+		run.mark_failed("Stopped by user.")
+	return {"status": run.status}
+
+
+@frappe.whitelist()
 def recover_session(session: str) -> dict[str, int]:
 	"""Fail any Running run on session (re)load. The client that owned the stream is
 	gone, so the run is abandoned; clearing it here unblocks the next turn instead of

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -134,21 +134,37 @@ class Agent:
 		"""Continue a run that paused on a question.
 
 		`answers` maps each pending tool_call_id to the user's answer: "Approve" runs
-		the tool, "Deny" blocks it, and any other free text is returned to the LLM as
-		redirect feedback so it can adjust and retry.
+		the tool, "Deny" records the rejection and stops the run, and any other free
+		text is returned to the LLM as redirect feedback so it can adjust and retry.
 		"""
 		if stream:
 			return self._resume_stream(messages, answers)
 		messages, _ = self._prepare_resume(messages, answers)
+		if _has_denial(answers):
+			return self._stopped_result(messages)
 		return self._loop(messages, self._answered_calls(messages))
 
 	def _resume_stream(self, messages: list[dict[str, Any]], answers: dict[str, Any]) -> Generator[Event]:
 		"""Stream a resume: first replay the just-resolved tool results so the UI can fill in
-		the tool cards that were awaiting an answer, then continue the agent loop."""
+		the tool cards that were awaiting an answer, then continue the agent loop (or stop
+		if the user denied)."""
 		messages, resolved = self._prepare_resume(messages, answers)
 		for call, content in resolved:
 			yield ToolEnded(id=call.id, name=call.name, result=content)
+		if _has_denial(answers):
+			yield Done(result=self._stopped_result(messages))
+			return
 		yield from self._loop_stream(messages, self._answered_calls(messages))
+
+	def _stopped_result(self, messages: list[dict[str, Any]]) -> RunResult:
+		"""Terminal result for a run the user denied: pending calls are already resolved in
+		`messages`, so end the turn here without another model call (no further tokens)."""
+		return RunResult(
+			output=None,
+			messages=messages,
+			tool_calls=self._answered_calls(messages),
+			iterations=0,
+		)
 
 	def new_session(self, *, title: str | None = None) -> Any:
 		"""Start a persisted conversation driven by this code agent (session's agent link is left empty)."""
@@ -416,6 +432,12 @@ def _confirmation_question(call: ToolCall, tool: Tool) -> Question:
 		options=["Approve", "Deny"],
 		allow_other=True,
 	)
+
+
+def _has_denial(answers: dict[str, Any]) -> bool:
+	"""A Deny answer halts the run — the user rejected an action, so stop rather than
+	continue. Approve and free-text (redirect) answers let the run proceed."""
+	return any(answer == "Deny" for answer in answers.values())
 
 
 def _serialize_tool_result(result: Any) -> str:

--- a/flow/tests/test_ai_agent.py
+++ b/flow/tests/test_ai_agent.py
@@ -638,25 +638,42 @@ class TestAgentConfirmation(UnitTestCase):
 		self.assertEqual(tool_message["content"], "wrote 2 bytes to /tmp/x")
 		self.assertEqual(resumed.output, "done")
 
-	def test_deny_skips_tool_and_returns_denial_to_llm(self):
+	def test_deny_records_rejection_and_stops_without_calling_model(self):
 		write_file, calls = self._danger_tool()
-		model = FakeModel(
-			[
-				_tool_call("write_file", {"path": "/tmp/x", "body": "hi"}, call_id="c1"),
-				_final("understood"),
-			]
-		)
+		# Only the pausing response is scripted: if resume called the model again,
+		# FakeModel would raise "ran out of scripted responses".
+		model = FakeModel([_tool_call("write_file", {"path": "/tmp/x", "body": "hi"}, call_id="c1")])
 		agent = Agent(model=model, tools=[write_file])
 
 		paused = agent.run("write hi to /tmp/x")
 		resumed = agent.resume(paused.messages, {"c1": "Deny"})
 
 		self.assertEqual(calls, [])  # tool never ran
+		self.assertFalse(resumed.paused)  # run ended, not paused
+		self.assertIsNone(resumed.output)
+		self.assertEqual(len(model.calls), 1)  # model not called again after Deny
 		tool_message = next(m for m in resumed.messages if m["role"] == "tool")
 		self.assertEqual(
 			json.loads(tool_message["content"]),
 			{"status": "denied", "message": "User denied this tool call."},
 		)
+
+	def test_stream_deny_stops_and_replays_denied_call(self):
+		write_file, calls = self._danger_tool()
+		model = FakeModel([_tool_call("write_file", {"path": "/tmp/x", "body": "hi"}, call_id="c1")])
+		agent = Agent(model=model, tools=[write_file])
+
+		paused = agent.run("write hi to /tmp/x")
+		events = list(agent.resume(paused.messages, {"c1": "Deny"}, stream=True))
+
+		self.assertEqual(calls, [])  # tool never ran
+		self.assertEqual(len(model.calls), 1)  # model not called again after Deny
+		# the denied call is replayed as a ToolEnded so the UI can fill its card, then Done
+		tool_ended = [e for e in events if isinstance(e, ToolEnded)]
+		self.assertEqual(len(tool_ended), 1)
+		self.assertEqual(json.loads(tool_ended[0].result)["status"], "denied")
+		self.assertIsInstance(events[-1], Done)
+		self.assertFalse(events[-1].result.paused)
 
 	def test_confirm_prompt_renders_plain_english_body(self):
 		@tool(

--- a/flow/tests/test_ai_api.py
+++ b/flow/tests/test_ai_api.py
@@ -219,7 +219,7 @@ class TestResumeRun(IntegrationTestCase):
 		run_name = self._pause(agent=self.agent.name)
 
 		with patch.object(Model, "chat", return_value=_final("ok")):
-			payload = resume_run(run_name, {"c1": "Deny"})
+			payload = resume_run(run_name, {"c1": "use a different approach"})
 
 		self.assertEqual(payload["status"], "Completed")
 		self.assertEqual(payload["output"], "ok")
@@ -228,15 +228,31 @@ class TestResumeRun(IntegrationTestCase):
 		run_name = self._pause(agent=None)
 
 		with patch.object(Model, "chat", return_value=_final("ok")):
+			payload = resume_run(run_name, {"c1": "use a different approach"})
+
+		self.assertEqual(payload["status"], "Completed")
+
+	def test_resume_deny_stops_run_without_calling_model(self):
+		run_name = self._pause(agent=self.agent.name)
+
+		called: list[bool] = []
+
+		def chat(self, messages, tools=None, *, stream=False):
+			called.append(True)
+			return _final("should not happen")
+
+		with patch.object(Model, "chat", new=chat):
 			payload = resume_run(run_name, {"c1": "Deny"})
 
 		self.assertEqual(payload["status"], "Completed")
+		self.assertEqual(called, [])  # model never called after Deny
+		self.assertEqual(frappe.get_doc("Flow Run", run_name).status, "Completed")
 
 	def test_resume_accepts_json_string_answers(self):
 		run_name = self._pause(agent=self.agent.name)
 
 		with patch.object(Model, "chat", return_value=_final("ok")):
-			payload = resume_run(run_name, json.dumps({"c1": "Deny"}))
+			payload = resume_run(run_name, json.dumps({"c1": "use a different approach"}))
 
 		self.assertEqual(payload["status"], "Completed")
 
@@ -244,7 +260,7 @@ class TestResumeRun(IntegrationTestCase):
 		run_name = self._pause(agent=self.agent.name)
 
 		with patch.object(Model, "chat", return_value=_confirm_call(call_id="c2")):
-			payload = resume_run(run_name, {"c1": "Deny"})
+			payload = resume_run(run_name, {"c1": "use a different approach"})
 
 		self.assertEqual(payload["status"], "Paused")
 		self.assertEqual(payload["questions"][0]["key"], "c2")
@@ -273,7 +289,7 @@ class TestResumeRun(IntegrationTestCase):
 		run_name = payload["name"]
 
 		with patch.object(Model, "chat", new=_stream_chat(["ok"], _final("ok"))):
-			response = resume_run(run_name, {"c1": "Deny"}, stream=True)
+			response = resume_run(run_name, {"c1": "use a different approach"}, stream=True)
 			self.assertIsInstance(response, Response)
 			events = _sse_events(response)
 
@@ -290,7 +306,7 @@ class TestResumeRun(IntegrationTestCase):
 
 		with patch.object(Model, "chat", side_effect=RuntimeError("boom")):
 			with self.assertRaises(RuntimeError):
-				resume_run(run_name, {"c1": "Deny"})
+				resume_run(run_name, {"c1": "use a different approach"})
 
 		failed = frappe.get_doc("Flow Run", run_name)
 		self.assertEqual(failed.status, "Failed")
@@ -504,7 +520,7 @@ class TestStartRunAttachments(IntegrationTestCase):
 
 		captured, chat = self._capture()
 		with patch.object(Model, "chat", side_effect=chat):
-			resume_run(paused["name"], {"c1": "Deny"})
+			resume_run(paused["name"], {"c1": "use a different approach"})
 
 		user_msgs = [m for m in captured[0] if m["role"] == "user"]
 		self.assertIn("the secret code is 1234", user_msgs[0]["content"])

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -47,6 +47,10 @@ export const getPausedRun = (session) =>
 // so a reloaded session isn't blocked from starting the next turn.
 export const recoverSession = (session) => frappe.xcall("flow.api.recover_session", { session });
 
+// Stop a run at the user's request: finalize an aborted stream's run or terminate a
+// paused run so the agent won't continue.
+export const stopRun = (run_name) => frappe.xcall("flow.api.stop_run", { run_name });
+
 // Map of the agent's tool slugs → requires_confirmation, so the panel can tell an
 // approval tool call from an inline one.
 export const getAgentTools = (agent) => frappe.xcall("flow.api.get_agent_tools", { agent });

--- a/frontend/src/api/stream.js
+++ b/frontend/src/api/stream.js
@@ -2,7 +2,7 @@ import { serverMessage } from "./client";
 
 // Consumes the run SSE stream: POSTs the request, then parses `data:` blocks
 // and hands each decoded event to `onEvent`.
-async function postStream(method, body, onEvent) {
+async function postStream(method, body, onEvent, signal) {
 	const resp = await fetch(`/api/method/${method}`, {
 		method: "POST",
 		headers: {
@@ -10,6 +10,7 @@ async function postStream(method, body, onEvent) {
 			"X-Frappe-CSRF-Token": frappe.csrf_token,
 		},
 		body: JSON.stringify({ ...body, stream: true }),
+		signal,
 	});
 	if (!resp.ok) {
 		const data = await resp.json().catch(() => ({}));
@@ -37,5 +38,7 @@ async function postStream(method, body, onEvent) {
 	}
 }
 
-export const startRun = (body, onEvent) => postStream("flow.api.start_run", body, onEvent);
-export const resumeRun = (body, onEvent) => postStream("flow.api.resume_run", body, onEvent);
+export const startRun = (body, onEvent, signal) =>
+	postStream("flow.api.start_run", body, onEvent, signal);
+export const resumeRun = (body, onEvent, signal) =>
+	postStream("flow.api.resume_run", body, onEvent, signal);

--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -24,6 +24,7 @@ const {
 	setAgent,
 	setModel,
 	send,
+	stopRun,
 	attachFiles,
 	removeAttachment,
 } = useStore();
@@ -205,7 +206,24 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 
 			<span class="flex-1"></span>
 
-			<Button variant="solid" :disabled="!canSend" :title="__('Send')" @click="submit">
+			<Button
+				v-if="sending"
+				theme="red"
+				class="!bg-surface-red-3 hover:!bg-surface-red-4"
+				:title="__('Stop')"
+				@click="stopRun"
+			>
+				<template #icon
+					><span class="h-2.5 w-2.5 rounded-[2px] bg-current"></span
+				></template>
+			</Button>
+			<Button
+				v-else
+				variant="solid"
+				:disabled="!canSend"
+				:title="__('Send')"
+				@click="submit"
+			>
 				<template #icon><FeatherIcon name="arrow-up" class="h-4 w-4" /></template>
 			</Button>
 		</div>

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -238,6 +238,9 @@ async function restorePausedRun(session) {
 }
 
 // ── sending / streaming ────────────────────────────────────────────────────────
+// Aborts the in-flight stream when the user stops the response.
+let abortController = null;
+
 async function send(text) {
 	text = text.trim();
 	if (!text || sending.value || paused.value || uploading.value) return;
@@ -250,6 +253,7 @@ async function send(text) {
 	messages.value.push({ id: nextId(), role: "user", content: text, attachments: chips });
 	const assistant = pushAssistant();
 	sending.value = true;
+	abortController = new AbortController();
 	requestScroll(true);
 
 	try {
@@ -261,11 +265,14 @@ async function send(text) {
 				...(selectedAgent.value && !sessionName.value && { agent: selectedAgent.value }),
 				...(selectedModel.value && { model: selectedModel.value }),
 			},
-			(event) => handleEvent(event, assistant)
+			(event) => handleEvent(event, assistant),
+			abortController.signal
 		);
 	} catch (e) {
-		failMessage(assistant, e);
+		if (e.name === "AbortError") assistant.pending = false;
+		else failMessage(assistant, e);
 	} finally {
+		abortController = null;
 		sending.value = false;
 		requestScroll();
 		focusTick.value++;
@@ -281,21 +288,38 @@ async function resume(answers, pausedMsg) {
 	pausedMsg.questions = [];
 	pausedMsg.pending = true;
 	sending.value = true;
+	abortController = new AbortController();
 	requestScroll(true);
 
 	try {
-		await resumeRun({ run_name: rn, answers }, (event) => handleEvent(event, pausedMsg));
+		await resumeRun(
+			{ run_name: rn, answers },
+			(event) => handleEvent(event, pausedMsg),
+			abortController.signal
+		);
 	} catch (e) {
-		failMessage(pausedMsg, e);
+		if (e.name === "AbortError") pausedMsg.pending = false;
+		else failMessage(pausedMsg, e);
 	} finally {
+		abortController = null;
 		sending.value = false;
 		requestScroll();
 		focusTick.value++;
 	}
 }
 
+// Stop the response: abort the live stream and finalize its run so the session
+// isn't left blocked. The backend agent loop unwinds on the aborted connection.
+function stopRun() {
+	if (!sending.value) return;
+	abortController?.abort();
+	const rn = runName.value;
+	if (rn) api.stopRun(rn).catch(() => {});
+}
+
 // Records one answer and stamps the tool's approval state; once every question
 // on the paused message is answered, resumes the run with all answers at once.
+// A Deny is sent through like any answer — the agent records it and stops the run.
 function answerQuestion(msg, question, answer) {
 	const a = (answer || "").trim();
 	if (!a || !msg) return;
@@ -448,6 +472,7 @@ export function useStore() {
 		newChat,
 		switchSession,
 		send,
+		stopRun,
 		answerQuestion,
 		attachFiles,
 		removeAttachment,

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -385,7 +385,24 @@ const makeToolPart = (id, name, args) => ({
 
 function setToolResult(msg, id, result) {
 	const part = msg.parts.find((p) => p.type === "tool" && p.id === id);
-	if (part) part.result = result;
+	if (!part) return;
+	part.result = result;
+	// On reload the live approval state is gone; recover it from the persisted
+	// confirmation result so the "Denied"/"Changes requested" badge survives.
+	if (part.approval === null) part.approval = approvalFromResult(result);
+}
+
+// A denied/redirected confirmation persists a known status payload as its tool result.
+function approvalFromResult(result) {
+	if (typeof result !== "string") return null;
+	try {
+		const status = JSON.parse(result)?.status;
+		if (status === "denied") return "denied";
+		if (status === "redirect") return "redirected";
+	} catch {
+		// a normal tool result, not a confirmation payload
+	}
+	return null;
 }
 
 function pushAssistant(pending = true) {

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -314,7 +314,10 @@ function stopRun() {
 	if (!sending.value) return;
 	abortController?.abort();
 	const rn = runName.value;
+	// Stopped before run_started arrived: no run name yet, so finalize any Running
+	// run on the session instead so the next turn isn't briefly blocked.
 	if (rn) api.stopRun(rn).catch(() => {});
+	else if (sessionName.value) api.recoverSession(sessionName.value).catch(() => {});
 }
 
 // Records one answer and stamps the tool's approval state; once every question

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -388,8 +388,11 @@ function setToolResult(msg, id, result) {
 	if (!part) return;
 	part.result = result;
 	// On reload the live approval state is gone; recover it from the persisted
-	// confirmation result so the "Denied"/"Changes requested" badge survives.
-	if (part.approval === null) part.approval = approvalFromResult(result);
+	// confirmation result so the "Denied"/"Changes requested" badge survives. Gated on
+	// the tool being a confirmation tool so a regular tool whose result happens to carry
+	// a {status: "denied"} payload isn't mislabeled.
+	if (part.approval === null && toolApproval.value[part.name] === true)
+		part.approval = approvalFromResult(result);
 }
 
 // A denied/redirected confirmation persists a known status payload as its tool result.


### PR DESCRIPTION
Adds the ability to stop an in-progress agent response.

- **Stop button**: while a response streams, Send becomes a Stop button that aborts the stream and finalizes the run via a new `stop_run` endpoint, so the session isn't left blocked.
- **Deny stops the run**: denying a tool-approval now records the denial and ends the turn (no further model call) instead of feeding "denied" back and continuing.