### PR TITLE
feat: protect system-generated rows

### DIFF
--- a/flow/flow/doctype/flow_agent/flow_agent.py
+++ b/flow/flow/doctype/flow_agent/flow_agent.py
@@ -10,6 +10,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from flow.system_generated import block_delete, block_rename, validate_immutable
+
 if TYPE_CHECKING:
 	from flow.flow.doctype.flow_run.flow_run import FlowRun
 	from flow.lib.agent import Agent, Event
@@ -44,18 +46,10 @@ class FlowAgent(Document):
 	# end: auto-generated types
 
 	def on_trash(self):
-		if self.is_system_generated:
-			frappe.throw(
-				_("Cannot delete system-generated agent {0}.").format(self.name),
-				title=_("Protected"),
-			)
+		block_delete(self, always=True)
 
 	def before_rename(self, old: str, _new: str, _merge: bool = False) -> None:
-		if self.is_system_generated:
-			frappe.throw(
-				_("Cannot rename system-generated agent {0}.").format(old),
-				title=_("Protected"),
-			)
+		block_rename(self, old)
 
 	def before_insert(self):
 		if not self.tools:
@@ -66,6 +60,7 @@ class FlowAgent(Document):
 	def validate(self):
 		self._validate_max_iterations()
 		self._ensure_knowledge_search_tool()
+		validate_immutable(self)
 
 	def _validate_max_iterations(self):
 		if self.max_iterations is not None and self.max_iterations < 1:

--- a/flow/flow/doctype/flow_agent/flow_agent.py
+++ b/flow/flow/doctype/flow_agent/flow_agent.py
@@ -10,7 +10,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from flow.system_generated import block_delete, block_rename, validate_immutable
+from flow.utils.system_generated import block_delete, block_rename, validate_immutable
 
 if TYPE_CHECKING:
 	from flow.flow.doctype.flow_run.flow_run import FlowRun

--- a/flow/flow/doctype/flow_agent/test_flow_agent.py
+++ b/flow/flow/doctype/flow_agent/test_flow_agent.py
@@ -286,3 +286,44 @@ class TestFlowAgentModelPermission(IntegrationTestCase):
 		self.assertIsInstance(self.agent_doc.assemble(model=self.allowed.name), Agent)
 		with self.assertRaises(frappe.PermissionError):
 			self.agent_doc.assemble()
+
+
+class TestFlowAgentSystemGenerated(IntegrationTestCase):
+	"""Desk edits can't break system-generated agents; the owning app (ignore_permissions) can."""
+
+	def setUp(self):
+		sync_builtin_tools()
+		self.model_doc = frappe.get_doc(_model()).insert()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _agent(self):
+		return frappe.get_doc(_agent(self.model_doc.name, is_system_generated=1)).insert()
+
+	def test_cannot_delete_via_desk(self):
+		agent = self._agent()
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot delete system-generated"):
+			frappe.delete_doc("Flow Agent", agent.name)
+
+	def test_delete_blocked_even_with_ignore_permissions(self):
+		agent = self._agent()
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot delete system-generated"):
+			frappe.delete_doc("Flow Agent", agent.name, ignore_permissions=True)
+
+	def test_cannot_rename(self):
+		agent = self._agent()
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot rename system-generated"):
+			frappe.rename_doc("Flow Agent", agent.name, "Renamed Agent")
+
+	def test_cannot_unset_flag(self):
+		agent = self._agent()
+		agent.is_system_generated = 0
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot remove the system-generated flag"):
+			agent.save()
+
+	def test_instructions_stay_editable(self):
+		agent = self._agent()
+		agent.instructions = "Be verbose."
+		agent.save()
+		self.assertEqual(frappe.db.get_value("Flow Agent", agent.name, "instructions"), "Be verbose.")

--- a/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.json
+++ b/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.json
@@ -8,6 +8,7 @@
  "field_order": [
   "title",
   "enabled",
+  "is_system_generated",
   "section_break_description",
   "description"
  ],
@@ -29,6 +30,13 @@
    "label": "Enabled"
   },
   {
+   "default": "0",
+   "fieldname": "is_system_generated",
+   "fieldtype": "Check",
+   "label": "System Generated",
+   "read_only": 1
+  },
+  {
    "fieldname": "section_break_description",
    "fieldtype": "Section Break"
   },
@@ -46,7 +54,7 @@
    "link_fieldname": "knowledge_base"
   }
  ],
- "modified": "2026-07-04 00:00:02.000000",
+ "modified": "2026-07-13 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Flow",
  "name": "Flow Knowledge Base",

--- a/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.py
+++ b/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.py
@@ -28,10 +28,19 @@ class FlowKnowledgeBase(Document):
 			)
 
 			require_embedding_model()
+		self._protect_system_generated_flag()
+
+	def _protect_system_generated_flag(self):
+		# Read the flag from the DB so unsetting it (which would bypass on_trash) is blocked.
+		if self.is_new() or self.flags.ignore_permissions or self.is_system_generated:
+			return
+		if frappe.db.get_value("Flow Knowledge Base", self.name, "is_system_generated"):
+			frappe.throw(
+				_("Cannot remove the system-generated flag from knowledge base {0}.").format(self.name),
+				title=_("Protected"),
+			)
 
 	def on_trash(self):
-		# System-generated bases are owned by the app that shipped them; block Desk users
-		# from deleting them while the owning app's sync (ignore_permissions) stays free.
 		if self.is_system_generated and not self.flags.ignore_permissions:
 			frappe.throw(
 				_("Cannot delete system-generated knowledge base {0}.").format(self.name),
@@ -39,9 +48,7 @@ class FlowKnowledgeBase(Document):
 			)
 
 	def before_rename(self, old: str, new: str, merge: bool = False) -> None:
-		# Unconditional: the title is the identity apps sync against, so a system base is
-		# never renamed (an app that wants a new title creates one and deletes the old).
-		# rename_doc doesn't propagate ignore_permissions here, so there's no escape hatch.
+		# Unconditional: the title is the app's sync identity; re-title via create + delete.
 		if self.is_system_generated:
 			frappe.throw(
 				_("Cannot rename system-generated knowledge base {0}.").format(old),

--- a/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.py
+++ b/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2026, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
-import frappe
-from frappe import _
 from frappe.model.document import Document
+
+from flow.utils.system_generated import block_delete, block_rename, validate_immutable
 
 
 class FlowKnowledgeBase(Document):
@@ -28,29 +28,10 @@ class FlowKnowledgeBase(Document):
 			)
 
 			require_embedding_model()
-		self._protect_system_generated_flag()
-
-	def _protect_system_generated_flag(self):
-		# Read the flag from the DB so unsetting it (which would bypass on_trash) is blocked.
-		if self.is_new() or self.flags.ignore_permissions or self.is_system_generated:
-			return
-		if frappe.db.get_value("Flow Knowledge Base", self.name, "is_system_generated"):
-			frappe.throw(
-				_("Cannot remove the system-generated flag from knowledge base {0}.").format(self.name),
-				title=_("Protected"),
-			)
+		validate_immutable(self)
 
 	def on_trash(self):
-		if self.is_system_generated and not self.flags.ignore_permissions:
-			frappe.throw(
-				_("Cannot delete system-generated knowledge base {0}.").format(self.name),
-				title=_("Protected"),
-			)
+		block_delete(self)
 
 	def before_rename(self, old: str, new: str, merge: bool = False) -> None:
-		# Unconditional: the title is the app's sync identity; re-title via create + delete.
-		if self.is_system_generated:
-			frappe.throw(
-				_("Cannot rename system-generated knowledge base {0}.").format(old),
-				title=_("Protected"),
-			)
+		block_rename(self, old)

--- a/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.py
+++ b/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -15,6 +17,7 @@ class FlowKnowledgeBase(Document):
 
 		description: DF.SmallText | None
 		enabled: DF.Check
+		is_system_generated: DF.Check
 		title: DF.Data
 	# end: auto-generated types
 
@@ -25,3 +28,19 @@ class FlowKnowledgeBase(Document):
 			)
 
 			require_embedding_model()
+
+	def on_trash(self):
+		# System-generated bases are owned by the app that shipped them; block Desk users
+		# from deleting them while the owning app's sync (ignore_permissions) stays free.
+		if self.is_system_generated and not self.flags.ignore_permissions:
+			frappe.throw(
+				_("Cannot delete system-generated knowledge base {0}.").format(self.name),
+				title=_("Protected"),
+			)
+
+	def before_rename(self, old: str, new: str, merge: bool = False) -> None:
+		if self.is_system_generated and not self.flags.ignore_permissions:
+			frappe.throw(
+				_("Cannot rename system-generated knowledge base {0}.").format(old),
+				title=_("Protected"),
+			)

--- a/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.py
+++ b/flow/flow/doctype/flow_knowledge_base/flow_knowledge_base.py
@@ -39,7 +39,10 @@ class FlowKnowledgeBase(Document):
 			)
 
 	def before_rename(self, old: str, new: str, merge: bool = False) -> None:
-		if self.is_system_generated and not self.flags.ignore_permissions:
+		# Unconditional: the title is the identity apps sync against, so a system base is
+		# never renamed (an app that wants a new title creates one and deletes the old).
+		# rename_doc doesn't propagate ignore_permissions here, so there's no escape hatch.
+		if self.is_system_generated:
 			frappe.throw(
 				_("Cannot rename system-generated knowledge base {0}.").format(old),
 				title=_("Protected"),

--- a/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.json
+++ b/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.json
@@ -9,6 +9,7 @@
   "knowledge_base",
   "column_break_meta",
   "source_type",
+  "is_system_generated",
   "section_break_input",
   "content",
   "file",
@@ -60,6 +61,13 @@
    "label": "Source Type",
    "options": "Text\nFile\nURL\nDocType",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_system_generated",
+   "fieldtype": "Check",
+   "label": "System Generated",
+   "read_only": 1
   },
   {
    "fieldname": "section_break_input",
@@ -192,7 +200,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-11 00:00:00",
+ "modified": "2026-07-13 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Flow",
  "name": "Flow Knowledge Source",

--- a/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.py
+++ b/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.py
@@ -66,15 +66,22 @@ class FlowKnowledgeSource(Document):
 		self._validate_system_generated_immutable()
 
 	def _validate_system_generated_immutable(self):
-		# Lock the structural identity of a system-generated source against Desk edits; the
-		# owning app's sync (ignore_permissions) may still update content, filters, etc.
-		if not self.is_system_generated or self.is_new() or self.flags.ignore_permissions:
+		# Gate on the DB flag so unsetting it can't bypass these guards.
+		if self.is_new() or self.flags.ignore_permissions:
 			return
 		before = frappe.db.get_value(
-			"Flow Knowledge Source", self.name, ["source_type", "knowledge_base"], as_dict=True
+			"Flow Knowledge Source",
+			self.name,
+			["source_type", "knowledge_base", "is_system_generated"],
+			as_dict=True,
 		)
-		if before is None:
+		if not before or not before.is_system_generated:
 			return
+		if not self.is_system_generated:
+			frappe.throw(
+				_("Cannot remove the system-generated flag from knowledge source {0}.").format(self.name),
+				title=_("Protected"),
+			)
 		if before.source_type != self.source_type:
 			frappe.throw(
 				_("Cannot change the type of system-generated knowledge source {0}.").format(self.name),

--- a/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.py
+++ b/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.py
@@ -32,6 +32,7 @@ class FlowKnowledgeSource(Document):
 		error_log: DF.LongText | None
 		file: DF.Attach | None
 		filters: DF.JSON | None
+		is_system_generated: DF.Check
 		knowledge_base: DF.Link
 		last_synced_at: DF.Datetime | None
 		reference_doctype: DF.Link | None
@@ -62,6 +63,30 @@ class FlowKnowledgeSource(Document):
 				frappe.MandatoryError,
 			)
 		self._validate_chunking()
+		self._validate_system_generated_immutable()
+
+	def _validate_system_generated_immutable(self):
+		# Lock the structural identity of a system-generated source against Desk edits; the
+		# owning app's sync (ignore_permissions) may still update content, filters, etc.
+		if not self.is_system_generated or self.is_new() or self.flags.ignore_permissions:
+			return
+		before = frappe.db.get_value(
+			"Flow Knowledge Source", self.name, ["source_type", "knowledge_base"], as_dict=True
+		)
+		if before is None:
+			return
+		if before.source_type != self.source_type:
+			frappe.throw(
+				_("Cannot change the type of system-generated knowledge source {0}.").format(self.name),
+				title=_("Protected"),
+			)
+		if before.knowledge_base != self.knowledge_base:
+			frappe.throw(
+				_("Cannot move system-generated knowledge source {0} to another knowledge base.").format(
+					self.name
+				),
+				title=_("Protected"),
+			)
 
 	def _validate_chunking(self):
 		"""0 inherits the global default. Only validate values set on the source itself."""
@@ -76,6 +101,11 @@ class FlowKnowledgeSource(Document):
 		enqueue_ingestion(self.name)
 
 	def on_trash(self):
+		if self.is_system_generated and not self.flags.ignore_permissions:
+			frappe.throw(
+				_("Cannot delete system-generated knowledge source {0}.").format(self.name),
+				title=_("Protected"),
+			)
 		from flow.knowledge.ingest import purge_source
 
 		purge_source(self.name)

--- a/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.py
+++ b/flow/flow/doctype/flow_knowledge_source/flow_knowledge_source.py
@@ -6,6 +6,8 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint
 
+from flow.utils.system_generated import block_delete, validate_immutable
+
 REQUIRED_INPUT = {
 	"Text": "content",
 	"File": "file",
@@ -63,37 +65,7 @@ class FlowKnowledgeSource(Document):
 				frappe.MandatoryError,
 			)
 		self._validate_chunking()
-		self._validate_system_generated_immutable()
-
-	def _validate_system_generated_immutable(self):
-		# Gate on the DB flag so unsetting it can't bypass these guards.
-		if self.is_new() or self.flags.ignore_permissions:
-			return
-		before = frappe.db.get_value(
-			"Flow Knowledge Source",
-			self.name,
-			["source_type", "knowledge_base", "is_system_generated"],
-			as_dict=True,
-		)
-		if not before or not before.is_system_generated:
-			return
-		if not self.is_system_generated:
-			frappe.throw(
-				_("Cannot remove the system-generated flag from knowledge source {0}.").format(self.name),
-				title=_("Protected"),
-			)
-		if before.source_type != self.source_type:
-			frappe.throw(
-				_("Cannot change the type of system-generated knowledge source {0}.").format(self.name),
-				title=_("Protected"),
-			)
-		if before.knowledge_base != self.knowledge_base:
-			frappe.throw(
-				_("Cannot move system-generated knowledge source {0} to another knowledge base.").format(
-					self.name
-				),
-				title=_("Protected"),
-			)
+		validate_immutable(self, ("source_type", "knowledge_base"))
 
 	def _validate_chunking(self):
 		"""0 inherits the global default. Only validate values set on the source itself."""
@@ -108,11 +80,7 @@ class FlowKnowledgeSource(Document):
 		enqueue_ingestion(self.name)
 
 	def on_trash(self):
-		if self.is_system_generated and not self.flags.ignore_permissions:
-			frappe.throw(
-				_("Cannot delete system-generated knowledge source {0}.").format(self.name),
-				title=_("Protected"),
-			)
+		block_delete(self)
 		from flow.knowledge.ingest import purge_source
 
 		purge_source(self.name)

--- a/flow/flow/doctype/flow_tool/flow_tool.py
+++ b/flow/flow/doctype/flow_tool/flow_tool.py
@@ -10,6 +10,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from flow.system_generated import block_delete, block_rename, validate_immutable
+
 SLUG_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 IMPORT_PATH_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$")
 MAIN_FUNCTION_NAME = "main"
@@ -42,38 +44,13 @@ class FlowTool(Document):
 		self._validate_type_fields()
 		if self.type == "Script":
 			self._validate_code()
-		self._validate_system_generated_immutable()
-
-	def _validate_system_generated_immutable(self):
-		if not self.is_system_generated or self.is_new():
-			return
-		before = frappe.db.get_value("Flow Tool", self.name, ["import_path", "type"], as_dict=True)
-		if before is None:
-			return
-		if before.import_path != self.import_path:
-			frappe.throw(
-				_("Cannot change import path of system-generated tool {0}.").format(self.name),
-				title=_("Protected"),
-			)
-		if before.type != self.type:
-			frappe.throw(
-				_("Cannot change type of system-generated tool {0}.").format(self.name),
-				title=_("Protected"),
-			)
+		validate_immutable(self, ("type", "import_path"))
 
 	def on_trash(self):
-		if self.is_system_generated:
-			frappe.throw(
-				_("Cannot delete system-generated tool {0}.").format(self.name),
-				title=_("Protected"),
-			)
+		block_delete(self, always=True)
 
 	def before_rename(self, old: str, _new: str, _merge: bool = False) -> None:
-		if self.is_system_generated:
-			frappe.throw(
-				_("Cannot rename system-generated tool {0}.").format(old),
-				title=_("Protected"),
-			)
+		block_rename(self, old)
 
 	def to_tool(self):
 		"""Resolve this row into a runtime Tool the Agent can call."""

--- a/flow/flow/doctype/flow_tool/flow_tool.py
+++ b/flow/flow/doctype/flow_tool/flow_tool.py
@@ -10,7 +10,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from flow.system_generated import block_delete, block_rename, validate_immutable
+from flow.utils.system_generated import block_delete, block_rename, validate_immutable
 
 SLUG_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 IMPORT_PATH_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$")

--- a/flow/flow/doctype/flow_tool/test_flow_tool.py
+++ b/flow/flow/doctype/flow_tool/test_flow_tool.py
@@ -97,3 +97,49 @@ class IntegrationTestFlowTool(IntegrationTestCase):
 		code = "def main(city: str):\n\treturn city\n\nmain('x')\n"
 		with self.assertRaisesRegex(frappe.ValidationError, "main"):
 			frappe.get_doc(_script(code=code)).insert()
+
+
+class TestFlowToolSystemGenerated(IntegrationTestCase):
+	"""Desk edits can't break system-generated tools; the owning app (ignore_permissions) can."""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _tool(self):
+		return frappe.get_doc(_module(is_system_generated=1)).insert()
+
+	def test_cannot_delete_via_desk(self):
+		tool = self._tool()
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot delete system-generated"):
+			frappe.delete_doc("Flow Tool", tool.name)
+
+	def test_delete_blocked_even_with_ignore_permissions(self):
+		tool = self._tool()
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot delete system-generated"):
+			frappe.delete_doc("Flow Tool", tool.name, ignore_permissions=True)
+
+	def test_cannot_unset_flag(self):
+		tool = self._tool()
+		tool.is_system_generated = 0
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot remove the system-generated flag"):
+			tool.save()
+
+	def test_cannot_change_import_path(self):
+		tool = self._tool()
+		tool.import_path = "flow.tools.builtins.execute"
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot change Import Path"):
+			tool.save()
+
+	def test_owning_app_can_change_import_path(self):
+		tool = self._tool()
+		tool.import_path = "flow.tools.builtins.execute"
+		tool.save(ignore_permissions=True)
+		self.assertEqual(
+			frappe.db.get_value("Flow Tool", tool.name, "import_path"), "flow.tools.builtins.execute"
+		)
+
+	def test_description_stays_editable(self):
+		tool = self._tool()
+		tool.description = "Updated description."
+		tool.save()
+		self.assertEqual(frappe.db.get_value("Flow Tool", tool.name, "description"), "Updated description.")

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -1356,7 +1356,7 @@ class TestSystemGeneratedProtection(IntegrationTestCase):
 		source = self._source(self._kb())
 		source.source_type = "URL"
 		source.url = "https://example.com"
-		with self.assertRaisesRegex(frappe.ValidationError, "Cannot change the type"):
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot change Source Type"):
 			source.save()
 
 	def test_owning_app_can_restructure_system_generated_source(self):

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -1291,3 +1291,83 @@ class TestRetrieveAttachments(IntegrationTestCase):
 		):
 			retrieve_attachments("refund", session="SES-x")
 		self.assertEqual(mocked.call_args.kwargs["text"], "refund")
+
+
+class TestSystemGeneratedProtection(IntegrationTestCase):
+	"""System-generated bases/sources are owned by the app that shipped them: the Desk
+	can't delete/rename/restructure them, but the owning app's sync (ignore_permissions)
+	retains full control."""
+
+	def setUp(self):
+		self.model = _make_model()
+		_set_settings(embedding_model=self.model.name, embedding_dimension=DIM)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def _kb(self, system=True, title="Builtin KB"):
+		return frappe.get_doc(
+			{"doctype": "Flow Knowledge Base", "title": title, "is_system_generated": int(system)}
+		).insert()
+
+	def _source(self, kb, system=True, **values):
+		values.setdefault("source_type", "Text")
+		values.setdefault("title", "Builtin Source")
+		values.setdefault("content", "some indexed content")
+		doc = frappe.get_doc(
+			{
+				"doctype": "Flow Knowledge Source",
+				"knowledge_base": kb.name,
+				"is_system_generated": int(system),
+				**values,
+			}
+		)
+		doc.flags.skip_auto_ingest = True
+		return doc.insert()
+
+	def test_cannot_delete_system_generated_kb_via_desk(self):
+		kb = self._kb()
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot delete system-generated"):
+			frappe.delete_doc("Flow Knowledge Base", kb.name)
+
+	def test_owning_app_can_delete_system_generated_kb(self):
+		kb = self._kb()
+		frappe.delete_doc("Flow Knowledge Base", kb.name, ignore_permissions=True)
+		self.assertFalse(frappe.db.exists("Flow Knowledge Base", kb.name))
+
+	def test_cannot_rename_system_generated_kb(self):
+		kb = self._kb()
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot rename system-generated"):
+			frappe.rename_doc("Flow Knowledge Base", kb.name, "Renamed KB")
+
+	def test_regular_kb_is_unaffected(self):
+		kb = self._kb(system=False, title="User KB")
+		frappe.delete_doc("Flow Knowledge Base", kb.name)
+		self.assertFalse(frappe.db.exists("Flow Knowledge Base", kb.name))
+
+	def test_cannot_delete_system_generated_source_via_desk(self):
+		source = self._source(self._kb())
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot delete system-generated"):
+			frappe.delete_doc("Flow Knowledge Source", source.name)
+
+	def test_cannot_change_type_of_system_generated_source_via_desk(self):
+		source = self._source(self._kb())
+		source.source_type = "URL"
+		source.url = "https://example.com"
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot change the type"):
+			source.save()
+
+	def test_owning_app_can_restructure_system_generated_source(self):
+		source = self._source(self._kb())
+		source.source_type = "URL"
+		source.url = "https://example.com"
+		source.save(ignore_permissions=True)
+		self.assertEqual(frappe.db.get_value("Flow Knowledge Source", source.name, "source_type"), "URL")
+
+	def test_content_of_system_generated_source_stays_editable(self):
+		source = self._source(self._kb())
+		source.content = "refreshed content"
+		source.save()  # structural identity unchanged, so a content edit is allowed
+		self.assertEqual(
+			frappe.db.get_value("Flow Knowledge Source", source.name, "content"), "refreshed content"
+		)

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -1294,9 +1294,7 @@ class TestRetrieveAttachments(IntegrationTestCase):
 
 
 class TestSystemGeneratedProtection(IntegrationTestCase):
-	"""System-generated bases/sources are owned by the app that shipped them: the Desk
-	can't delete/rename/restructure them, but the owning app's sync (ignore_permissions)
-	retains full control."""
+	"""Desk edits can't break app-owned system rows; the app's sync (ignore_permissions) can."""
 
 	def setUp(self):
 		self.model = _make_model()
@@ -1339,8 +1337,6 @@ class TestSystemGeneratedProtection(IntegrationTestCase):
 		from frappe.model.rename_doc import rename_doc
 
 		kb = self._kb()
-		# Blocked outright, even via the low-level API with ignore_permissions: the title is
-		# the sync identity, so apps re-title by create+delete rather than rename.
 		with self.assertRaisesRegex(frappe.ValidationError, "Cannot rename system-generated"):
 			frappe.rename_doc("Flow Knowledge Base", kb.name, "Renamed KB")
 		with self.assertRaisesRegex(frappe.ValidationError, "Cannot rename system-generated"):
@@ -1373,7 +1369,19 @@ class TestSystemGeneratedProtection(IntegrationTestCase):
 	def test_content_of_system_generated_source_stays_editable(self):
 		source = self._source(self._kb())
 		source.content = "refreshed content"
-		source.save()  # structural identity unchanged, so a content edit is allowed
+		source.save()
 		self.assertEqual(
 			frappe.db.get_value("Flow Knowledge Source", source.name, "content"), "refreshed content"
 		)
+
+	def test_cannot_unset_system_generated_flag_on_kb(self):
+		kb = self._kb()
+		kb.is_system_generated = 0
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot remove the system-generated flag"):
+			kb.save()
+
+	def test_cannot_unset_system_generated_flag_on_source(self):
+		source = self._source(self._kb())
+		source.is_system_generated = 0
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot remove the system-generated flag"):
+			source.save()

--- a/flow/tests/test_knowledge.py
+++ b/flow/tests/test_knowledge.py
@@ -1336,9 +1336,15 @@ class TestSystemGeneratedProtection(IntegrationTestCase):
 		self.assertFalse(frappe.db.exists("Flow Knowledge Base", kb.name))
 
 	def test_cannot_rename_system_generated_kb(self):
+		from frappe.model.rename_doc import rename_doc
+
 		kb = self._kb()
+		# Blocked outright, even via the low-level API with ignore_permissions: the title is
+		# the sync identity, so apps re-title by create+delete rather than rename.
 		with self.assertRaisesRegex(frappe.ValidationError, "Cannot rename system-generated"):
 			frappe.rename_doc("Flow Knowledge Base", kb.name, "Renamed KB")
+		with self.assertRaisesRegex(frappe.ValidationError, "Cannot rename system-generated"):
+			rename_doc("Flow Knowledge Base", kb.name, "Renamed KB", ignore_permissions=True)
 
 	def test_regular_kb_is_unaffected(self):
 		kb = self._kb(system=False, title="User KB")

--- a/flow/utils/system_generated.py
+++ b/flow/utils/system_generated.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+"""Guards for rows flagged `is_system_generated`.
+
+Such rows are owned by the app that ships them: permission-checked (Desk/API)
+writes cannot break them, while the owning app keeps full control by passing
+`ignore_permissions=True`. Renames are blocked outright because frappe's
+rename_doc never propagates ignore_permissions to the doc.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+
+
+def validate_immutable(doc, fields: tuple[str, ...] = ()) -> None:
+	"""Call from validate. Blocks unsetting the flag and edits to `fields`, comparing
+	against DB values so tampering with the flag can't disarm the other guards."""
+	if doc.is_new() or doc.flags.ignore_permissions:
+		return
+	before = frappe.db.get_value(doc.doctype, doc.name, ["is_system_generated", *fields], as_dict=True)
+	if not before or not before.is_system_generated:
+		return
+	if not doc.is_system_generated:
+		frappe.throw(
+			_("Cannot remove the system-generated flag from {0} {1}.").format(_(doc.doctype), doc.name),
+			title=_("Protected"),
+		)
+	for fieldname in fields:
+		if before.get(fieldname) != doc.get(fieldname):
+			frappe.throw(
+				_("Cannot change {0} of system-generated {1} {2}.").format(
+					_(doc.meta.get_label(fieldname)), _(doc.doctype), doc.name
+				),
+				title=_("Protected"),
+			)
+
+
+def block_delete(doc, always: bool = False) -> None:
+	"""Call from on_trash. `always=True` blocks even the owning app — for rows Flow
+	itself ships (builtin agent/tools) that must never disappear."""
+	if doc.is_system_generated and (always or not doc.flags.ignore_permissions):
+		frappe.throw(
+			_("Cannot delete system-generated {0} {1}.").format(_(doc.doctype), doc.name),
+			title=_("Protected"),
+		)
+
+
+def block_rename(doc, old: str) -> None:
+	"""Call from before_rename."""
+	if doc.is_system_generated:
+		frappe.throw(
+			_("Cannot rename system-generated {0} {1}.").format(_(doc.doctype), old),
+			title=_("Protected"),
+		)


### PR DESCRIPTION
Lets apps (e.g. Helpdesk) ship builtin knowledge and other system rows and manage them via their own migrate-time sync, without users breaking them from the Desk.

## What
- Adds an `is_system_generated` flag to **Flow Knowledge Base** and **Flow Knowledge Source**.
- Extracts shared guards in `flow/utils/system_generated.py` (`validate_immutable`, `block_delete`, `block_rename`) and adopts them across Flow Knowledge Base/Source, **Flow Agent**, and **Flow Tool** — replacing the per-controller copies.
- Closes a pre-existing hole on Flow Agent/Tool: the flag itself was unprotected, so unsetting it (via API or an agent's `update` tool — `read_only` isn't server-enforced) disarmed every other guard. Guards now compare against the DB value and block the unset.

## Protection model
Gated on `ignore_permissions`, so the Desk blocks users while the owning app keeps full programmatic control:
- Can't delete a system row, rename it, unset its flag, or change locked structural fields (`source_type`/`knowledge_base` on a source, `type`/`import_path` on a tool).
- Content/description/enabled/etc. stay editable so apps can refresh.
- Flow's own builtins (the "Flow" assistant + builtin tools) block deletion unconditionally (`block_delete(always=True)`) — they're recreated on migrate and must never disappear.

Apps manage their own rows via `insert/save/delete_doc(ignore_permissions=True)`. Flow provides no sync engine — apps own that.

Tests cover both the Desk blocks and the app's programmatic escapes across all four doctypes.