### PR TITLE
feat: sandboxed trigger conditions and a Run As identity

### DIFF
--- a/flow/flow/doctype/flow_trigger/flow_trigger.json
+++ b/flow/flow/doctype/flow_trigger/flow_trigger.json
@@ -12,6 +12,7 @@
   "agent",
   "event",
   "auto_approve",
+  "run_as",
   "section_break_when",
   "target_doctype",
   "doc_event",
@@ -73,6 +74,13 @@
    "label": "Auto Approve Tool Calls"
   },
   {
+   "description": "Run the agent as this user, so its tools act with a defined, least-privilege permission scope. Defaults to the trigger's owner when empty. Prefer a purpose-scoped service user over a full administrator.",
+   "fieldname": "run_as",
+   "fieldtype": "Link",
+   "label": "Run As",
+   "options": "User"
+  },
+  {
    "fieldname": "section_break_when",
    "fieldtype": "Section Break",
    "label": "When"
@@ -123,7 +131,7 @@
    "label": "Condition"
   },
   {
-   "description": "Optional Python expression. For DocType events, <code>doc</code> is in scope. Trigger only fires if the expression is truthy, e.g. <code>doc.status == \"Open\" and doc.priority == \"High\"</code>",
+   "description": "Optional Python condition; the trigger fires only if it is truthy. A single expression (e.g. <code>doc.status == \"Open\"</code>) or a script that sets <code>result</code>. Runs in the server-script sandbox with <code>doc</code> in scope for DocType events.",
    "fieldname": "condition",
    "fieldtype": "Code",
    "label": "Condition",
@@ -150,7 +158,7 @@
    "link_fieldname": "trigger"
   }
  ],
- "modified": "2026-07-04 00:00:01.000000",
+ "modified": "2026-07-14 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Flow",
  "name": "Flow Trigger",

--- a/flow/flow/doctype/flow_trigger/flow_trigger.py
+++ b/flow/flow/doctype/flow_trigger/flow_trigger.py
@@ -28,6 +28,7 @@ class FlowTrigger(Document):
 		event: DF.Literal["DocType Event", "Scheduled"]
 		last_fired_at: DF.Datetime | None
 		prompt_template: DF.Code
+		run_as: DF.Link | None
 		target_doctype: DF.Link | None
 		title: DF.Data
 	# end: auto-generated types
@@ -37,6 +38,16 @@ class FlowTrigger(Document):
 		self._validate_cron()
 		self._validate_condition()
 		self._validate_template()
+		self._validate_run_as()
+
+	def _validate_run_as(self):
+		if not self.run_as:
+			return
+		if self.run_as == "Guest" or not frappe.db.get_value("User", self.run_as, "enabled"):
+			frappe.throw(
+				_("Run As must be an enabled user."),
+				title=_("Invalid Run As"),
+			)
 
 	def _validate_event_fields(self):
 		if self.event == "DocType Event":
@@ -60,12 +71,9 @@ class FlowTrigger(Document):
 			frappe.throw(_("Invalid cron expression: {0}").format(e), title=_("Invalid Cron"))
 
 	def _validate_condition(self):
-		if not self.condition:
-			return
-		try:
-			compile(self.condition, "<ai_trigger_condition>", "eval")
-		except SyntaxError as e:
-			frappe.throw(_("Invalid condition expression: {0}").format(e), title=_("Invalid Condition"))
+		from flow.utils.conditions import validate_condition
+
+		validate_condition(self.condition)
 
 	def _validate_template(self):
 		from jinja2 import TemplateSyntaxError

--- a/flow/tests/test_ai_triggers.py
+++ b/flow/tests/test_ai_triggers.py
@@ -71,6 +71,7 @@ class TestDispatch(IntegrationTestCase):
 	def setUpClass(cls):
 		super().setUpClass()
 		sync_builtin_tools()
+		cls.enterClassContext(cls.enable_safe_exec())
 
 	def setUp(self):
 		self.model = frappe.get_doc(_model()).insert()
@@ -140,6 +141,39 @@ class TestDispatch(IntegrationTestCase):
 		with patch("frappe.enqueue") as enqueue:
 			dispatch(closed_doc, "after_insert")
 		enqueue.assert_called_once()
+
+	def test_dispatch_evaluates_multiline_condition(self):
+		self.trigger.condition = (
+			"status = frappe.db.get_value('ToDo', doc.name, 'status')\nresult = status == 'Closed'"
+		)
+		self.trigger.save()
+		open_doc = frappe.get_doc({"doctype": "ToDo", "description": "open one"}).insert()
+		closed_doc = frappe.get_doc(
+			{"doctype": "ToDo", "description": "closed one", "status": "Closed"}
+		).insert()
+
+		with patch("frappe.enqueue") as enqueue:
+			dispatch(open_doc, "after_insert")
+		enqueue.assert_not_called()
+
+		with patch("frappe.enqueue") as enqueue:
+			dispatch(closed_doc, "after_insert")
+		enqueue.assert_called_once()
+
+	def test_condition_runtime_error_skips_trigger(self):
+		self.trigger.condition = "doc.status.no_such_method()"
+		self.trigger.save()
+		doc = frappe.get_doc({"doctype": "ToDo", "description": "boom"}).insert()
+
+		with patch("frappe.enqueue") as enqueue:
+			dispatch(doc, "after_insert")
+
+		enqueue.assert_not_called()
+
+	def test_condition_script_without_result_rejected_on_save(self):
+		self.trigger.condition = "status = doc.status"
+		with self.assertRaisesRegex(frappe.ValidationError, "result"):
+			self.trigger.save()
 
 	def test_disabled_trigger_does_not_dispatch(self):
 		self.trigger.enabled = 0
@@ -220,6 +254,7 @@ class TestFire(IntegrationTestCase):
 	def setUpClass(cls):
 		super().setUpClass()
 		sync_builtin_tools()
+		cls.enterClassContext(cls.enable_safe_exec())
 
 	def setUp(self):
 		self.model = frappe.get_doc(_model()).insert()
@@ -244,6 +279,71 @@ class TestFire(IntegrationTestCase):
 		self.assertIn(todo.name, run.input)
 		self.assertEqual(run.reference_doctype, "ToDo")
 		self.assertEqual(run.reference_name, todo.name)
+
+	def test_fire_runs_as_trigger_owner_not_triggering_user(self):
+		# Helpdesk scenario: a low-privilege user (no Flow Agent access) fires the trigger by
+		# creating a doc; the agent must still run, with the owner's authority.
+		owner = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "trigger-owner@example.com",
+				"first_name": "Owner",
+				"roles": [{"role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True)
+		customer = frappe.get_doc(
+			{"doctype": "User", "email": "trigger-customer@example.com", "first_name": "Cust"}
+		).insert(ignore_permissions=True)
+		frappe.db.set_value("Flow Trigger", self.trigger.name, "owner", owner.name)
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "help me"}).insert()
+
+		frappe.set_user(customer.name)
+		try:
+			with patch.object(Model, "chat", return_value=_final("done")):
+				run_name = fire(self.trigger.name, target_doctype="ToDo", target_name=todo.name)
+		finally:
+			frappe.set_user("Administrator")
+
+		self.assertIsNotNone(run_name)
+		run = frappe.get_doc("Flow Run", run_name)
+		self.assertEqual(run.status, "Completed")
+		self.assertEqual(run.owner, owner.name)
+		self.assertEqual(frappe.get_doc("Flow Session", run.session).owner, owner.name)
+
+	def test_fire_runs_as_configured_run_as_user(self):
+		# run_as overrides the owner: the agent runs with that user's scope.
+		service_user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "trigger-service@example.com",
+				"first_name": "Service",
+				"roles": [{"role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True)
+		self.trigger.run_as = service_user.name
+		self.trigger.save()
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "run-as"}).insert()
+
+		with patch.object(Model, "chat", return_value=_final("done")):
+			run_name = fire(self.trigger.name, target_doctype="ToDo", target_name=todo.name)
+
+		run = frappe.get_doc("Flow Run", run_name)
+		self.assertEqual(run.owner, service_user.name)
+		self.assertEqual(run.status, "Completed")
+
+	def test_run_as_disabled_user_rejected(self):
+		disabled = frappe.get_doc(
+			{"doctype": "User", "email": "trigger-disabled@example.com", "first_name": "Off", "enabled": 0}
+		).insert(ignore_permissions=True)
+		self.trigger.run_as = disabled.name
+		with self.assertRaisesRegex(frappe.ValidationError, "Run As must be an enabled user"):
+			self.trigger.save()
+
+	def test_fire_restores_the_original_user(self):
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "restore"}).insert()
+		with patch.object(Model, "chat", return_value=_final("done")):
+			fire(self.trigger.name, target_doctype="ToDo", target_name=todo.name)
+		self.assertEqual(frappe.session.user, "Administrator")
 
 	def _execute_then_final(self):
 		from flow.lib.model import ToolCall

--- a/flow/tests/test_ai_triggers.py
+++ b/flow/tests/test_ai_triggers.py
@@ -160,6 +160,27 @@ class TestDispatch(IntegrationTestCase):
 			dispatch(closed_doc, "after_insert")
 		enqueue.assert_called_once()
 
+	def test_dispatch_evaluates_condition_as_run_as(self):
+		# The pre-enqueue check runs as run_as, not the triggering user.
+		service = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": "dispatch-service@example.com",
+				"first_name": "Svc",
+				"roles": [{"role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True)
+		self.trigger.run_as = service.name
+		self.trigger.condition = f"frappe.session.user == '{service.name}'"
+		self.trigger.save()
+		doc = frappe.get_doc({"doctype": "ToDo", "description": "run-as cond"}).insert()
+
+		with patch("frappe.enqueue") as enqueue:
+			dispatch(doc, "after_insert")
+
+		enqueue.assert_called_once()
+		self.assertEqual(frappe.session.user, "Administrator")  # restored afterward
+
 	def test_condition_runtime_error_skips_trigger(self):
 		self.trigger.condition = "doc.status.no_such_method()"
 		self.trigger.save()

--- a/flow/tests/test_conditions.py
+++ b/flow/tests/test_conditions.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from flow.utils.conditions import evaluate_condition, validate_condition
+
+
+class TestValidateCondition(IntegrationTestCase):
+	def test_empty_condition_is_valid(self):
+		validate_condition(None)
+		validate_condition("")
+
+	def test_expression_is_valid(self):
+		validate_condition("doc.status == 'Open' and doc.priority == 'High'")
+
+	def test_script_setting_result_is_valid(self):
+		validate_condition("status = doc.status\nresult = status == 'Open'")
+
+	def test_script_without_result_is_rejected(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "result"):
+			validate_condition("status = doc.status")
+
+	def test_syntax_error_is_rejected(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "Invalid condition"):
+			validate_condition("doc.status ==")
+
+
+class TestEvaluateCondition(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls.enterClassContext(cls.enable_safe_exec())
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_expression_verdict(self):
+		doc = frappe._dict(status="Open")
+		self.assertTrue(evaluate_condition("doc.status == 'Open'", {"doc": doc}))
+		self.assertFalse(evaluate_condition("doc.status == 'Closed'", {"doc": doc}))
+
+	def test_multiline_script_verdict(self):
+		script = "words = doc.description.split()\nresult = len(words) > 2"
+		self.assertTrue(evaluate_condition(script, {"doc": frappe._dict(description="a b c d")}))
+		self.assertFalse(evaluate_condition(script, {"doc": frappe._dict(description="a b")}))
+
+	def test_condition_can_query_db(self):
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "db check", "status": "Closed"}).insert()
+		condition = 'frappe.db.get_value("ToDo", doc.name, "status") == "Closed"'
+		self.assertTrue(evaluate_condition(condition, {"doc": frappe._dict(name=todo.name)}))
+
+	def test_runtime_error_raises(self):
+		with self.assertRaises(Exception):
+			evaluate_condition("undefined_name > 1", {"doc": frappe._dict()})
+
+	def test_sandbox_blocks_imports(self):
+		with self.assertRaises(Exception):
+			evaluate_condition("import os\nresult = True", {"doc": frappe._dict()})

--- a/flow/tests/test_conditions.py
+++ b/flow/tests/test_conditions.py
@@ -26,6 +26,14 @@ class TestValidateCondition(IntegrationTestCase):
 		with self.assertRaisesRegex(frappe.ValidationError, "Invalid condition"):
 			validate_condition("doc.status ==")
 
+	def test_result_in_control_flow_is_valid(self):
+		validate_condition("if doc.status == 'Open':\n\tresult = True\nelse:\n\tresult = False")
+
+	def test_result_only_in_nested_scope_is_rejected(self):
+		# `result` set inside a def never reaches the exec globals, so it must be rejected.
+		with self.assertRaisesRegex(frappe.ValidationError, "result"):
+			validate_condition("def check():\n\tresult = True")
+
 
 class TestEvaluateCondition(IntegrationTestCase):
 	@classmethod

--- a/flow/triggers/triggers.py
+++ b/flow/triggers/triggers.py
@@ -26,7 +26,7 @@ def dispatch(doc: Document, method: str | None = None) -> None:
 	triggers = _doctype_triggers(doc.doctype, method)
 
 	for trigger in triggers:
-		if trigger.condition and not _eval_condition(trigger.condition, doc):
+		if trigger.condition and not _passes_condition(trigger, doc):
 			continue
 		frappe.enqueue(
 			"flow.triggers.fire",
@@ -107,8 +107,20 @@ def _doctype_triggers(target_doctype: str, doc_event: str) -> list:
 			"doc_event": doc_event,
 			"enabled": 1,
 		},
-		fields=["name", "condition"],
+		fields=["name", "condition", "run_as", "owner"],
 	)
+
+
+def _passes_condition(trigger, doc: Document) -> bool:
+	"""Evaluate the pre-enqueue condition as the trigger's run identity (matching fire),
+	so a permission-sensitive condition doesn't silently under-fire for the low-privilege
+	user whose action triggered it."""
+	original_user = frappe.session.user
+	frappe.set_user(trigger.run_as or trigger.owner)
+	try:
+		return _eval_condition(trigger.condition, doc)
+	finally:
+		frappe.set_user(original_user)
 
 
 def _eval_condition(condition: str, doc: Document) -> bool:

--- a/flow/triggers/triggers.py
+++ b/flow/triggers/triggers.py
@@ -70,26 +70,32 @@ def fire(
 	if not t.enabled:
 		return None
 
-	doc = None
-	if target_doctype and target_name:
-		try:
-			doc = frappe.get_doc(target_doctype, target_name)
-		except frappe.DoesNotExistError:
-			return None
-		if t.condition and not _eval_condition(t.condition, doc):
-			return None
+	# A trigger runs as its configured `run_as` user (falling back to the owner)
+	original_user = frappe.session.user
+	frappe.set_user(t.run_as or t.owner)
+	try:
+		doc = None
+		if target_doctype and target_name:
+			try:
+				doc = frappe.get_doc(target_doctype, target_name)
+			except frappe.DoesNotExistError:
+				return None
+			if t.condition and not _eval_condition(t.condition, doc):
+				return None
 
-	prompt = frappe.render_template(t.prompt_template, {"doc": doc, "now": frappe.utils.now_datetime()})
-	agent_doc = frappe.get_doc("Flow Agent", t.agent)
-	run = agent_doc.run(
-		prompt,
-		source="Trigger",
-		trigger=t.name,
-		reference_doctype=target_doctype if doc else None,
-		reference_name=target_name if doc else None,
-		auto_approve=bool(t.auto_approve),
-	)
-	return run.name
+		prompt = frappe.render_template(t.prompt_template, {"doc": doc, "now": frappe.utils.now_datetime()})
+		agent_doc = frappe.get_doc("Flow Agent", t.agent)
+		run = agent_doc.run(
+			prompt,
+			source="Trigger",
+			trigger=t.name,
+			reference_doctype=target_doctype if doc else None,
+			reference_name=target_name if doc else None,
+			auto_approve=bool(t.auto_approve),
+		)
+		return run.name
+	finally:
+		frappe.set_user(original_user)
 
 
 def _doctype_triggers(target_doctype: str, doc_event: str) -> list:
@@ -106,10 +112,13 @@ def _doctype_triggers(target_doctype: str, doc_event: str) -> list:
 
 
 def _eval_condition(condition: str, doc: Document) -> bool:
-	from frappe.integrations.doctype.webhook.webhook import get_context
+	from frappe.utils.safe_exec import get_safe_globals
 
+	from flow.utils.conditions import evaluate_condition
+
+	context = {"doc": doc, "utils": get_safe_globals().get("frappe").get("utils")}
 	try:
-		return bool(frappe.safe_eval(condition, eval_locals=get_context(doc)))
+		return evaluate_condition(condition, context)
 	except Exception:
 		frappe.log_error(title="Flow Trigger condition eval failed")
 		return False

--- a/flow/utils/conditions.py
+++ b/flow/utils/conditions.py
@@ -54,19 +54,44 @@ def _is_expression(condition: str) -> bool:
 		return False
 
 
-def _assigns_result(tree: ast.Module) -> bool:
-	for node in ast.walk(tree):
-		if isinstance(node, ast.Assign):
-			targets = node.targets
-		elif isinstance(node, ast.AugAssign | ast.AnnAssign | ast.NamedExpr):
-			targets = [node.target]
-		else:
+# Scopes that don't execute in the module body, so a `result` assigned inside them
+# never reaches the exec globals the verdict is read from.
+_NESTED_SCOPES = (
+	ast.FunctionDef,
+	ast.AsyncFunctionDef,
+	ast.ClassDef,
+	ast.Lambda,
+	ast.ListComp,
+	ast.SetComp,
+	ast.DictComp,
+	ast.GeneratorExp,
+)
+
+
+def _assigns_result(node: ast.AST) -> bool:
+	"""Whether `result` is assigned in the module's own scope. Recurses through control
+	flow (if/for/try) but not into nested scopes, which never run in the exec globals."""
+	for child in ast.iter_child_nodes(node):
+		if isinstance(child, _NESTED_SCOPES):
 			continue
-		for target in targets:
-			if isinstance(target, ast.Name) and target.id == RESULT_VAR:
-				return True
-			if isinstance(target, ast.Tuple | ast.List) and any(
-				isinstance(el, ast.Name) and el.id == RESULT_VAR for el in target.elts
-			):
-				return True
+		if _targets_result(child) or _assigns_result(child):
+			return True
+	return False
+
+
+def _targets_result(node: ast.AST) -> bool:
+	if isinstance(node, ast.Assign):
+		targets = node.targets
+	elif isinstance(node, ast.AugAssign | ast.AnnAssign | ast.NamedExpr):
+		targets = [node.target]
+	else:
+		return False
+	return any(_is_result_name(target) for target in targets)
+
+
+def _is_result_name(target: ast.AST) -> bool:
+	if isinstance(target, ast.Name):
+		return target.id == RESULT_VAR
+	if isinstance(target, ast.Tuple | ast.List):
+		return any(_is_result_name(el) for el in target.elts)
 	return False

--- a/flow/utils/conditions.py
+++ b/flow/utils/conditions.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+"""User-authored conditions, run in the server-script sandbox (safe_exec).
+
+A condition is either a single Python expression whose value is the verdict,
+or a multi-line script that sets a `result` variable. Authoring is restricted
+to System Managers (Flow Trigger / Flow Knowledge Source permissions), the
+same trust level frappe requires for Server Scripts.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+import frappe
+from frappe import _
+from frappe.utils.safe_exec import safe_exec
+
+RESULT_VAR = "result"
+
+
+def validate_condition(condition: str | None) -> None:
+	"""Save-time check: a single expression, or a script that sets `result`."""
+	if not condition:
+		return
+	if _is_expression(condition):
+		return
+	try:
+		tree = ast.parse(condition)
+	except SyntaxError as e:
+		frappe.throw(_("Invalid condition: {0}").format(e), title=_("Invalid Condition"))
+	if not _assigns_result(tree):
+		frappe.throw(
+			_("A multi-line condition must set a <code>result</code> variable."),
+			title=_("Invalid Condition"),
+		)
+
+
+def evaluate_condition(condition: str, context: dict[str, Any]) -> bool:
+	"""Run `condition` in the sandbox with `context` in scope; return the verdict.
+	Raises on execution errors — callers decide how to fail."""
+	script = f"{RESULT_VAR} = ({condition}\n)" if _is_expression(condition) else condition
+	exec_globals, _locals = safe_exec(script, context, script_filename="flow_condition")
+	return bool(exec_globals.get(RESULT_VAR))
+
+
+def _is_expression(condition: str) -> bool:
+	try:
+		compile(condition, "<flow_condition>", "eval")
+		return True
+	except SyntaxError:
+		return False
+
+
+def _assigns_result(tree: ast.Module) -> bool:
+	for node in ast.walk(tree):
+		if isinstance(node, ast.Assign):
+			targets = node.targets
+		elif isinstance(node, ast.AugAssign | ast.AnnAssign | ast.NamedExpr):
+			targets = [node.target]
+		else:
+			continue
+		for target in targets:
+			if isinstance(target, ast.Name) and target.id == RESULT_VAR:
+				return True
+			if isinstance(target, ast.Tuple | ast.List) and any(
+				isinstance(el, ast.Name) and el.id == RESULT_VAR for el in target.elts
+			):
+				return True
+	return False


### PR DESCRIPTION
## Conditions
Flow Trigger conditions now run in the server-script sandbox (`safe_exec`) instead of a single `safe_eval` expression. A condition can be a single expression **or** a multi-line script that sets `result`, so it can do lookups and complex logic. Validated at save time; authoring stays System-Manager-only.

## Run As identity
Doc-event triggers previously ran as whoever's action fired them, so a low-privilege user (e.g. a customer creating a ticket) couldn't drive the agent. `fire()` now runs as the trigger's `run_as` user, falling back to the owner — the run and session are owned by that identity and it's restored afterward.

New **Run As** (Link → User) field lets admins scope the agent to a least-privilege service user rather than a full admin, bounding the blast radius of prompt-injection via user-controlled fields. Rejects disabled/Guest users.