### PR TITLE
feat: permission-respecting sandbox for the execute tool

### DIFF
--- a/flow/tests/test_safe_exec.py
+++ b/flow/tests/test_safe_exec.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from flow.utils.safe_exec import get_flow_safe_globals, safe_exec
+
+
+class TestFlowSafeExecNamespace(IntegrationTestCase):
+	def test_excludes_permission_bypassing_functions(self):
+		g = get_flow_safe_globals()
+		for name in ("sql", "set_value", "get_all", "commit", "rollback", "add_index", "escape"):
+			self.assertNotIn(name, g.frappe.db)
+		self.assertNotIn("get_all", g.frappe)
+		self.assertNotIn("qb", g.frappe)
+		self.assertNotIn("csrf_token", g.frappe.session)
+
+	def test_includes_permission_respecting_helpers(self):
+		g = get_flow_safe_globals()
+		self.assertIn("get_list", g.frappe)
+		for name in ("get_value", "get_single_value", "exists", "count"):
+			self.assertIn(name, g.frappe.db)
+
+	def test_injects_write_builtins_but_not_execute(self):
+		g = get_flow_safe_globals()
+		for name in ("create", "update", "delete", "run_action", "read", "describe", "find_doctypes"):
+			self.assertIn(name, g)
+		self.assertNotIn("execute", g)
+		self.assertNotIn("search_knowledge", g)
+
+
+class TestFlowSafeExec(IntegrationTestCase):
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+
+	def _run(self, code):
+		exec_globals, _ = safe_exec(code, script_filename="test")
+		return exec_globals.get("result")
+
+	def test_computation(self):
+		self.assertEqual(self._run("result = sum([1, 2, 3])"), 6)
+
+	def test_utils_available(self):
+		self.assertEqual(self._run('result = frappe.utils.cint("5")'), 5)
+
+	def test_blocks_import(self):
+		with self.assertRaises(ImportError):
+			safe_exec("import os")
+
+	def test_blocks_dunder_access(self):
+		with self.assertRaises(SyntaxError):
+			safe_exec("result = ().__class__")
+
+	def test_raw_sql_unavailable(self):
+		with self.assertRaises(AttributeError):
+			safe_exec('result = frappe.db.sql("select 1")')
+
+	def test_set_value_unavailable(self):
+		with self.assertRaises(AttributeError):
+			safe_exec('frappe.db.set_value("ToDo", "x", "status", "Open")')
+
+	def test_get_all_unavailable(self):
+		with self.assertRaises(AttributeError):
+			safe_exec('result = frappe.get_all("ToDo")')
+
+	def test_get_list_supports_aggregates(self):
+		frappe.get_doc({"doctype": "ToDo", "description": "agg a", "status": "Open"}).insert()
+		frappe.get_doc({"doctype": "ToDo", "description": "agg b", "status": "Open"}).insert()
+		rows = self._run(
+			'result = frappe.get_list("ToDo", filters={"status": "Open"}, fields=[{"COUNT": "*", "as": "total"}])'
+		)
+		self.assertGreaterEqual(rows[0]["total"], 2)
+
+	def test_count_returns_number(self):
+		frappe.get_doc({"doctype": "ToDo", "description": "count me", "status": "Open"}).insert()
+		self.assertGreaterEqual(self._run('result = frappe.db.count("ToDo")'), 1)
+
+	def test_create_builtin_writes(self):
+		result = self._run('result = create("ToDo", [{"description": "made in sandbox"}])')
+		self.assertEqual(len(result["created"]), 1)
+		self.assertTrue(frappe.db.exists("ToDo", result["created"][0]))
+
+	def test_get_doc_enforces_read_permission(self):
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "secret", "status": "Open"}).insert()
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			safe_exec(f'result = frappe.get_doc("ToDo", "{todo.name}")')
+
+	def test_create_enforces_create_permission(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(PermissionError):
+			safe_exec('result = create("ToDo", [{"description": "denied"}])')
+
+	def test_get_list_ignore_permissions_is_stripped(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			safe_exec('result = frappe.get_list("User", fields=["name"], ignore_permissions=True)')
+
+	def test_db_get_list_ignore_permissions_is_stripped(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			safe_exec('result = frappe.db.get_list("User", fields=["name"], ignore_permissions=True)')
+
+	def test_get_list_ignore_user_permissions_is_stripped(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			safe_exec('result = frappe.get_list("User", fields=["name"], ignore_user_permissions=True)')
+
+	def test_get_list_user_impersonation_is_stripped(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			safe_exec('result = frappe.get_list("User", fields=["name"], user="Administrator")')
+
+	def test_render_template_is_unavailable(self):
+		with self.assertRaises(AttributeError):
+			safe_exec('result = frappe.render_template("{{ 1 }}", {})')

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -8,9 +8,9 @@ from typing import Any
 
 import frappe
 from frappe import _
-from frappe.utils.safe_exec import safe_exec
 
 from flow.lib.tool import Tool, tool
+from flow.utils.safe_exec import safe_exec
 
 MAX_READ_LIMIT = 200
 LAYOUT_FIELDTYPES = frozenset({"Section Break", "Column Break", "Tab Break", "HTML", "Heading"})
@@ -149,23 +149,37 @@ search_knowledge = bind_search_knowledge([])
 	confirm_prompt=lambda args: f"Run this Python:\n\n{args.get('code', '')}",
 )
 def execute(code: str) -> Any:
-	"""Run Python in the Frappe sandbox (RestrictedPython) for computation, emails, or multi-record work.
+	"""Run Python in a permission-respecting sandbox for computation, emails, or multi-record work.
 
-	Assign the value you want returned to a variable named `result`.
-	Example:
+	Do NOT write `import` statements — imports are blocked and the whole script fails. `frappe`
+	and `frappe.utils` are already in scope; everything you can use is listed below, so never
+	start with `import ...`.
+
+	Every function here enforces the current user's permissions — there is no way to read or
+	write data the user cannot access. Assign the value to return to a variable named `result`.
+	Example (no imports, just use `frappe` directly):
 	    result = frappe.db.count("ToDo", {"status": "Open"})
+
+	Available:
+	- Reads: frappe.get_list (supports group_by and aggregates via dict fields, e.g.
+	  fields=[{"SUM": "qty", "as": "total"}] or [{"COUNT": "*", "as": "n"}]),
+	  frappe.get_doc (returns a dict), frappe.get_meta, frappe.db.get_value/get_single_value/count/exists.
+	- Writes: create, update, delete, run_action — the same permission-checked tools you call directly.
+	- Also: read, describe, find_doctypes, frappe.call (whitelisted methods), frappe.enqueue,
+	  frappe.sendmail, frappe.get_print, frappe.utils.* (dates, numbers, strings).
 
 	Sandbox limits — code using these FAILS:
 	- No `import`. `frappe` and `frappe.utils` are already in scope; nothing else can be imported.
 	- No names or attributes starting with `_` (no dunders, no `obj._private`).
+	- No raw database access: frappe.db.sql, frappe.qb, frappe.db.set_value and frappe.get_all are
+	  unavailable — use frappe.get_list and the write tools, which respect permissions.
 	- Unavailable builtins: open, eval, exec, compile, getattr, setattr, hasattr,
 	  globals, locals, vars, dir, type, input. Available: len, range, str, int, float,
 	  bool, sum, sorted, enumerate, zip, min, max, abs, dict, list, set, tuple.
 	- `str.format()` / `.format_map()` are blocked — use f-strings or `%` formatting.
-	- `frappe.db.sql` is read-only (SELECT/EXPLAIN only).
 	- `print()` output is logged, not returned — put what you want back into `result`.
 
-	Writes run as the current user and enforce permissions. The user approves each call before it runs.
+	The user approves each call before it runs.
 	"""
 	exec_globals, _locals = safe_exec(code, script_filename="ai_execute")
 	return exec_globals.get("result")

--- a/flow/utils/safe_exec.py
+++ b/flow/utils/safe_exec.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# License: MIT. See LICENSE
+
+"""A permission-respecting sandbox for Flow's `execute` tool.
+
+Reuses frappe's RestrictedPython machinery (compilation, guards, flags) but exposes
+an allowlisted namespace where every data function enforces the current user's
+permissions. Functions that bypass permissions — raw SQL, the query builder,
+`db.set_value`, `get_all` — are left out entirely.
+"""
+
+from __future__ import annotations
+
+import json
+import mimetypes
+from typing import Any
+
+import frappe
+import RestrictedPython.Guards
+from frappe import _
+from frappe.core.utils import html2text
+from frappe.utils.inplacevar import protected_inplacevar
+from frappe.utils.safe_exec import (
+	SAFE_DATA_UTILS,
+	SAFE_EXCEPTIONS,
+	SAFE_ORJSON,
+	SERVER_SCRIPT_FILE_PREFIX,
+	FrappePrintCollector,
+	NamespaceDict,
+	_compile_code,
+	_getattr_for_safe_exec,
+	_getitem,
+	_write,
+	call_whitelisted_function,
+	get_python_builtins,
+	is_job_queued,
+	safe_enqueue,
+	safe_exec_flags,
+	safer_get_meta,
+	safer_log_error,
+)
+from RestrictedPython import safe_globals
+
+
+def safe_exec(
+	script: str,
+	_globals: dict | None = None,
+	_locals: dict | None = None,
+	*,
+	script_filename: str | None = None,
+):
+	exec_globals = get_flow_safe_globals()
+	if _globals:
+		exec_globals.update(_globals)
+
+	filename = SERVER_SCRIPT_FILE_PREFIX
+	if script_filename:
+		filename += f": {frappe.scrub(script_filename)}"
+
+	with safe_exec_flags():
+		exec(_compile_code(script, filename=filename), exec_globals, _locals)
+
+	return exec_globals, _locals
+
+
+def _gated_get_doc(*args: Any, **kwargs: Any) -> dict:
+	doc = frappe.get_doc(*args, **kwargs)
+	doc.check_permission("read")
+	return doc.as_dict()
+
+
+def _gated_get_last_doc(*args: Any, **kwargs: Any) -> dict:
+	doc = frappe.get_last_doc(*args, **kwargs)
+	doc.check_permission("read")
+	return doc.as_dict()
+
+
+def _gated_get_meta(doctype: str, cached: bool = True) -> dict | None:
+	if not frappe.has_permission(doctype, "read"):
+		raise frappe.PermissionError(_("No permission to read {0}").format(doctype))
+	return safer_get_meta(doctype, cached)
+
+
+def _gated_get_print(doctype=None, name=None, *args: Any, **kwargs: Any):
+	if doctype and name and not frappe.has_permission(doctype, "read", name):
+		raise frappe.PermissionError(_("No permission to read {0} {1}").format(doctype, name))
+	return frappe.get_print(doctype, name, *args, **kwargs)
+
+
+def _gated_attach_print(doctype: str, name: str, *args: Any, **kwargs: Any):
+	if not frappe.has_permission(doctype, "read", name):
+		raise frappe.PermissionError(_("No permission to read {0} {1}").format(doctype, name))
+	return frappe.attach_print(doctype, name, *args, **kwargs)
+
+
+def _permissioned_get_list(doctype, *args, **kwargs):
+	for unsafe in ("ignore_permissions", "ignore_user_permissions", "user"):
+		kwargs.pop(unsafe, None)
+	return frappe.get_list(
+		doctype,
+		*args,
+		ignore_permissions=False,
+		ignore_user_permissions=False,
+		user=frappe.session.user,
+		**kwargs,
+	)
+
+
+def _permissioned_get_value(doctype, filters=None, fieldname="name", *, as_dict=False):
+	if isinstance(filters, str):
+		filters = {"name": filters}
+	fieldnames = fieldname if isinstance(fieldname, (list, tuple)) else [fieldname]
+	rows = _permissioned_get_list(doctype, filters=filters, fields=list(fieldnames), limit=1)
+	if not rows:
+		return None
+	row = rows[0]
+	if as_dict:
+		return row
+	if isinstance(fieldname, (list, tuple)):
+		return [row.get(f) for f in fieldname]
+	return row.get(fieldname)
+
+
+def _permissioned_get_single_value(doctype: str, fieldname: str):
+	if not frappe.has_permission(doctype, "read"):
+		raise frappe.PermissionError(_("No permission to read {0}").format(doctype))
+	return frappe.db.get_single_value(doctype, fieldname)
+
+
+def _permissioned_exists(doctype, filters=None) -> bool:
+	if isinstance(filters, str):
+		filters = {"name": filters}
+	return bool(_permissioned_get_list(doctype, filters=filters, fields=["name"], limit=1))
+
+
+def _permissioned_count(doctype, filters=None) -> int:
+	rows = _permissioned_get_list(doctype, filters=filters, fields=[{"COUNT": "*", "as": "total"}])
+	return rows[0].get("total") if rows else 0
+
+
+_SKIP_BUILTINS = frozenset({"execute", "search_knowledge"})
+
+
+def _flow_builtins() -> dict[str, Any]:
+	"""The permission-checked builtins, callable as plain functions inside the sandbox.
+	`execute` (no recursion) and `search_knowledge` (needs a bound scope) are left out."""
+	from flow.tools.builtins import BUILTIN_TOOLS
+
+	return {t.name: t.func for t in BUILTIN_TOOLS if t.name not in _SKIP_BUILTINS}
+
+
+def get_flow_safe_globals() -> NamespaceDict:
+	user = frappe.session.user
+
+	out = NamespaceDict(
+		json=NamespaceDict(loads=json.loads, dumps=json.dumps),
+		orjson=SAFE_ORJSON,
+		as_json=frappe.as_json,
+		dict=dict,
+		_dict=frappe._dict,
+		log=frappe.log,
+		_=frappe._,
+		scrub=frappe.scrub,
+		html2text=html2text,
+		guess_mimetype=mimetypes.guess_type,
+		frappe=NamespaceDict(
+			call=call_whitelisted_function,
+			enqueue=safe_enqueue,
+			is_job_queued=is_job_queued,
+			user=user,
+			session=frappe._dict(user=user),
+			get_doc=_gated_get_doc,
+			get_last_doc=_gated_get_last_doc,
+			get_meta=_gated_get_meta,
+			get_list=_permissioned_get_list,
+			get_print=_gated_get_print,
+			attach_print=_gated_attach_print,
+			sendmail=frappe.sendmail,
+			log=frappe.log,
+			log_error=safer_log_error,
+			msgprint=frappe.msgprint,
+			throw=frappe.throw,
+			errprint=frappe.errprint,
+			bold=frappe.bold,
+			sanitize_html=frappe.utils.sanitize_html,
+			get_fullname=frappe.utils.get_fullname,
+			format=frappe.format_value,
+			format_value=frappe.format_value,
+			utils=NamespaceDict(**SAFE_DATA_UTILS),
+			db=NamespaceDict(
+				get_list=_permissioned_get_list,
+				get_value=_permissioned_get_value,
+				get_single_value=_permissioned_get_single_value,
+				exists=_permissioned_exists,
+				count=_permissioned_count,
+			),
+		),
+	)
+
+	out.frappe.update(SAFE_EXCEPTIONS)
+	out.update(_flow_builtins())
+
+	out.update(safe_globals)
+	out._write_ = _write
+	out._getitem_ = _getitem
+	out._getattr_ = _getattr_for_safe_exec
+	out._print_ = FrappePrintCollector
+	out._getiter_ = iter
+	out._iter_unpack_sequence_ = RestrictedPython.Guards.guarded_iter_unpack_sequence
+	out._inplacevar_ = protected_inplacevar
+	out.update(get_python_builtins())
+
+	return out


### PR DESCRIPTION
The `execute` tool used Frappe's `safe_exec`, whose namespace bypasses permissions (raw SQL, `qb`, `db.set_value`, `get_all(ignore_permissions)`). This adds `flow/utils/safe_exec.py` — same RestrictedPython machinery, but an allowlisted namespace where every read/write enforces the running user's permissions. No dependency on `server_script_enabled`.

Hardening (all regression-tested): `get_list` escape kwargs pinned (`ignore_permissions`, `ignore_user_permissions`, `user`); `render_template` removed (its restricted Jinja env still exposed `get_all`/`sql`/`qb`); `get_doc` returns a dict (no mutable Document); writes routed through the permission-checked builtins.