### PR TITLE
docs: note server scripts requirement for script tools and conditions

### DIFF
--- a/flow/flow/doctype/flow_tool/flow_tool.json
+++ b/flow/flow/doctype/flow_tool/flow_tool.json
@@ -106,7 +106,7 @@
   },
   {
    "depends_on": "eval:doc.type === 'Script'",
-   "description": "Python source. Must define a top-level <code>main</code> function. Executed in a server-script sandbox.",
+   "description": "Python source. Must define a top-level <code>main</code> function. Executed in a server-script sandbox. Requires server scripts to be enabled in the bench configuration.",
    "fieldname": "code",
    "fieldtype": "Code",
    "label": "Code",

--- a/flow/flow/doctype/flow_trigger/flow_trigger.json
+++ b/flow/flow/doctype/flow_trigger/flow_trigger.json
@@ -131,7 +131,7 @@
    "label": "Condition"
   },
   {
-   "description": "Optional Python condition; the trigger fires only if it is truthy. A single expression (e.g. <code>doc.status == \"Open\"</code>) or a script that sets <code>result</code>. Runs in the server-script sandbox with <code>doc</code> in scope for DocType events.",
+   "description": "Optional Python condition; the trigger fires only if it is truthy. A single expression (e.g. <code>doc.status == \"Open\"</code>) or a script that sets <code>result</code>. Runs in the server-script sandbox with <code>doc</code> in scope for DocType events. Requires server scripts to be enabled in the bench configuration; without it the condition is treated as not met and the trigger does not fire.",
    "fieldname": "condition",
    "fieldtype": "Code",
    "label": "Condition",

--- a/flow/flow/doctype/flow_trigger/flow_trigger.json
+++ b/flow/flow/doctype/flow_trigger/flow_trigger.json
@@ -131,7 +131,7 @@
    "label": "Condition"
   },
   {
-   "description": "Optional Python condition; the trigger fires only if it is truthy. A single expression (e.g. <code>doc.status == \"Open\"</code>) or a script that sets <code>result</code>. Runs in the server-script sandbox with <code>doc</code> in scope for DocType events. Requires server scripts to be enabled in the bench configuration; without it the condition is treated as not met and the trigger does not fire.",
+   "description": "Optional Python condition; the trigger fires only if it is truthy. A single expression (e.g. <code>doc.status == \"Open\"</code>), or a multi-line script that must assign the verdict to a variable named <code>result</code>. Runs in the server-script sandbox with <code>doc</code> in scope for DocType events. Requires server scripts to be enabled in the bench configuration; without it the condition is treated as not met and the trigger does not fire.",
    "fieldname": "condition",
    "fieldtype": "Code",
    "label": "Condition",


### PR DESCRIPTION
Script-type Flow Tools and Flow Trigger conditions run in Frappe's `safe_exec`, which requires server scripts enabled. When disabled, a Script tool errors and a trigger condition is treated as not met (the trigger does not fire).

Documents this in the `code` (Script tools only) and `condition` field descriptions so it's visible at the point of authoring.