### PR TITLE
Improve panel readability and persist state across reloads

### DIFF
--- a/frontend/src/components/CodeBlock.vue
+++ b/frontend/src/components/CodeBlock.vue
@@ -43,7 +43,7 @@ const shown = computed(() =>
 	background: var(--surface-gray-2);
 	padding: 8px 10px;
 	font-family: var(--font-stack-monospace, ui-monospace, monospace);
-	font-size: 11.5px;
+	font-size: 12.5px;
 	line-height: 1.6;
 	color: var(--ink-gray-8);
 }

--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -168,7 +168,7 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 			>
 				<template #trigger="{ toggle }">
 					<button
-						class="flex h-6 items-center gap-1 rounded px-1.5 text-[11.5px] text-ink-gray-6 hover:bg-surface-gray-2 disabled:cursor-default disabled:hover:bg-transparent"
+						class="flex h-6 items-center gap-1 rounded px-1.5 text-[12.5px] text-ink-gray-6 hover:bg-surface-gray-2 disabled:cursor-default disabled:hover:bg-transparent"
 						:disabled="locked"
 						:title="__('Agent')"
 						@click="toggle"
@@ -192,7 +192,7 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 			>
 				<template #trigger="{ toggle }">
 					<button
-						class="flex h-6 items-center gap-1 rounded px-1.5 text-[11.5px] text-ink-gray-6 hover:bg-surface-gray-2"
+						class="flex h-6 items-center gap-1 rounded px-1.5 text-[12.5px] text-ink-gray-6 hover:bg-surface-gray-2"
 						:title="__('Model')"
 						@click="toggle"
 					>

--- a/frontend/src/components/Composer.vue
+++ b/frontend/src/components/Composer.vue
@@ -109,7 +109,7 @@ watch(focusTick, () => nextTick(() => el.value?.focus()));
 
 <template>
 	<div
-		class="flow-composer absolute inset-x-4 bottom-3.5 mx-auto flex max-w-3xl flex-col gap-1.5 rounded-xl border bg-surface-white px-2.5 py-2 shadow-sm transition-[border-color,background-color] focus-within:border-outline-gray-3"
+		class="flow-composer absolute inset-x-5 bottom-3.5 mx-auto flex max-w-3xl flex-col gap-1.5 rounded-xl border bg-surface-white px-2.5 py-2 shadow-sm transition-[border-color,background-color] focus-within:border-outline-gray-3"
 		:class="dragging ? 'border-outline-gray-4 bg-surface-gray-1' : 'border-outline-gray-2'"
 		@dragover="onDragOver"
 		@dragleave="onDragLeave"

--- a/frontend/src/components/ConfirmCard.vue
+++ b/frontend/src/components/ConfirmCard.vue
@@ -126,7 +126,7 @@ function sendOther() {
 	border: 1px solid var(--outline-gray-1);
 	border-radius: 6px;
 	font-family: var(--font-stack-monospace, ui-monospace, monospace);
-	font-size: 11.5px;
+	font-size: 12.5px;
 	line-height: 1.55;
 	color: var(--ink-gray-8);
 	white-space: pre-wrap;

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -40,7 +40,7 @@ watch(scrollTick, () => {
 <template>
 	<div
 		ref="el"
-		class="flow-scrollbar flex flex-1 flex-col overflow-y-auto px-4 pt-4 pb-[calc(var(--flow-composer-h,104px)+24px)]"
+		class="flow-scrollbar flex flex-1 flex-col overflow-y-auto px-5 pt-4 pb-[calc(var(--flow-composer-h,104px)+24px)]"
 		@scroll="onScroll"
 	>
 		<div class="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-5">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,6 +6,13 @@
 
 /* Authored rules are scoped to #flow-root by postcss-prefix-selector at build. */
 
+:root {
+	--text-xs: 13px;
+	--text-sm: 14px;
+	--text-base: 15px;
+	--text-lg: 17px;
+}
+
 /* frappe-ui forces `font-family: InterVar`, a face the desk doesn't load (it
    ships "Inter"/"InterVariable"), so it falls back to the system font. Point
    the panel at the desk's real fonts. */

--- a/frontend/src/lib/panelState.js
+++ b/frontend/src/lib/panelState.js
@@ -1,0 +1,18 @@
+// Persists the panel's open/fullscreen/width/session across reloads.
+const KEY = "flow-panel-state";
+
+export function readPanelState() {
+	try {
+		return JSON.parse(localStorage.getItem(KEY)) || {};
+	} catch {
+		return {};
+	}
+}
+
+export function writePanelState(state) {
+	try {
+		localStorage.setItem(KEY, JSON.stringify(state));
+	} catch {
+		// storage unavailable — persistence is best-effort
+	}
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,7 @@
-import { createApp } from "vue";
+import { createApp, watch } from "vue";
 import App from "@/App.vue";
 import { useStore } from "@/store";
+import { readPanelState, writePanelState } from "@/lib/panelState";
 import "@/index.css";
 
 const PANEL_WIDTH = 420;
@@ -11,29 +12,43 @@ const MIN_WIDTH = 360;
 // that id so nothing leaks onto the desk.
 class FlowPanel {
 	constructor() {
-		this.visible = false;
+		const saved = readPanelState();
+		this.visible = Boolean(saved.open);
+		this._halfWidth = saved.width || PANEL_WIDTH;
+		// Fullscreen is the default mode; a saved preference wins on reload.
+		this._initialFullscreen = saved.fullscreen ?? true;
+
 		this._mount();
 		this._syncTheme();
 		this._registerShortcut();
+
+		watch(this.store.sessionName, () => this._persist());
+	}
+
+	get fullscreen() {
+		return this.store.fullscreen.value;
 	}
 
 	_mount() {
+		this.store = useStore();
+		this.store.fullscreen.value = this._initialFullscreen;
+
 		this.root = document.createElement("div");
 		this.root.id = "flow-root";
 		Object.assign(this.root.style, {
 			position: "fixed",
 			top: "0",
 			right: "0",
-			width: `${PANEL_WIDTH}px`,
+			width: this.fullscreen ? "100vw" : `${this._halfWidth}px`,
 			height: "100vh",
 			zIndex: "1040",
-			transform: "translateX(100%)",
+			// A restored-open panel renders in place (no slide) so a refresh is seamless.
+			transform: this.visible ? "translateX(0)" : "translateX(100%)",
 			transition: "transform 0.22s ease",
 			boxShadow: "-2px 0 16px rgba(0, 0, 0, 0.08)",
 		});
 		document.body.appendChild(this.root);
 
-		this.store = useStore();
 		this.app = createApp(App, {
 			onClose: () => this.hide(),
 			onToggleFullscreen: () => this.toggleFullscreen(),
@@ -63,6 +78,7 @@ class FlowPanel {
 			const max = window.innerWidth - 80;
 			const width = Math.min(max, Math.max(MIN_WIDTH, window.innerWidth - e.clientX));
 			this.root.style.width = `${width}px`;
+			this._halfWidth = width;
 			// A manual resize takes the panel out of fullscreen; keep the header icon honest.
 			this.store.fullscreen.value = false;
 		};
@@ -71,6 +87,7 @@ class FlowPanel {
 			document.removeEventListener("mouseup", onUp);
 			document.body.style.userSelect = "";
 			this.root.style.transition = this._savedTransition;
+			this._persist();
 		};
 		handle.addEventListener("mousedown", (e) => {
 			e.preventDefault();
@@ -109,28 +126,35 @@ class FlowPanel {
 	show() {
 		this.visible = true;
 		this.root.style.transform = "translateX(0)";
+		this._persist();
 	}
 
 	hide() {
 		this.visible = false;
 		this.root.style.transform = "translateX(100%)";
+		this._persist();
 	}
 
 	toggle() {
 		this.visible ? this.hide() : this.show();
 	}
 
-	// Expand the panel to the full viewport width, or restore its previous
-	// width. State lives in the store so the header icon tracks it reactively.
+	// Expand to the full viewport width, or restore the half-screen width. State
+	// lives in the store so the header icon tracks it reactively.
 	toggleFullscreen() {
-		const next = !this.store.fullscreen.value;
+		const next = !this.fullscreen;
 		this.store.fullscreen.value = next;
-		if (next) {
-			this._savedWidth = this.root.style.width;
-			this.root.style.width = "100vw";
-		} else {
-			this.root.style.width = this._savedWidth || `${PANEL_WIDTH}px`;
-		}
+		this.root.style.width = next ? "100vw" : `${this._halfWidth}px`;
+		this._persist();
+	}
+
+	_persist() {
+		writePanelState({
+			open: this.visible,
+			fullscreen: this.fullscreen,
+			width: this._halfWidth,
+			session: this.store.sessionName.value,
+		});
 	}
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -126,6 +126,7 @@ class FlowPanel {
 	show() {
 		this.visible = true;
 		this.root.style.transform = "translateX(0)";
+		this.store.restoreSession();
 		this._persist();
 	}
 

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -2,6 +2,7 @@ import { ref, computed } from "vue";
 import * as api from "@/api/client";
 import { startRun, resumeRun } from "@/api/stream";
 import { normalizeToolName } from "@/lib/toolMeta";
+import { readPanelState } from "@/lib/panelState";
 import { __ } from "@/lib/translate";
 
 // Module-singleton store: one panel instance, one source of truth. Components
@@ -67,6 +68,16 @@ async function loadInitial() {
 		loadToolApproval(selectedAgent.value);
 		loaded.value = true;
 		focusTick.value++;
+
+		// Reopen the session that was active before a reload, even if the panel was closed.
+		const saved = readPanelState();
+		if (saved.session) {
+			try {
+				await switchSession(saved.session);
+			} catch {
+				newChat();
+			}
+		}
 	} catch {
 		// `loaded` stays false, keeping the composer disabled on "Loading…".
 		frappe.show_alert({

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -69,21 +69,26 @@ async function loadInitial() {
 		loaded.value = true;
 		focusTick.value++;
 
-		// Reopen the session that was active before a reload, even if the panel was closed.
-		const saved = readPanelState();
-		if (saved.session) {
-			try {
-				await switchSession(saved.session);
-			} catch {
-				newChat();
-			}
-		}
+		if (readPanelState().open) await restoreSession();
 	} catch {
 		// `loaded` stays false, keeping the composer disabled on "Loading…".
 		frappe.show_alert({
 			message: __("Flow failed to load. Refresh the page to retry."),
 			indicator: "red",
 		});
+	}
+}
+
+let sessionRestored = false;
+async function restoreSession() {
+	if (sessionRestored) return;
+	sessionRestored = true;
+	const { session } = readPanelState();
+	if (!session) return;
+	try {
+		await switchSession(session);
+	} catch {
+		newChat();
 	}
 }
 
@@ -500,6 +505,7 @@ export function useStore() {
 		modelLabel,
 		// actions
 		loadInitial,
+		restoreSession,
 		refreshHistory,
 		setAgent,
 		setModel,

--- a/frontend/src/styles/markdown.css
+++ b/frontend/src/styles/markdown.css
@@ -30,7 +30,7 @@
 	font-size: var(--text-lg);
 }
 .md h2 {
-	font-size: 15px;
+	font-size: 16px;
 }
 .md h3 {
 	font-size: var(--text-base);
@@ -73,7 +73,7 @@
 }
 .md code {
 	font-family: var(--font-stack-monospace, ui-monospace, monospace);
-	font-size: 12px;
+	font-size: 13px;
 	background: var(--surface-gray-2);
 	padding: 1px 5px;
 	border-radius: 5px;
@@ -89,7 +89,7 @@
 .md pre code {
 	background: transparent;
 	padding: 0;
-	font-size: 12px;
+	font-size: 13px;
 }
 /* Wide tables scroll inside their own box instead of widening the panel. */
 .md .md-table-scroll {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -15,6 +15,28 @@ export default {
 		"./node_modules/frappe-ui/src/composables/**/*.{vue,js,ts}",
 		"./node_modules/frappe-ui/src/utils/**/*.{vue,js,ts}",
 	],
-	theme: { extend: {} },
+	theme: {
+		extend: {
+			fontSize: {
+				"2xs": [
+					"12px",
+					{ lineHeight: "1.15", letterSpacing: "0.01em", fontWeight: "420" },
+				],
+				xs: ["13px", { lineHeight: "1.15", letterSpacing: "0.02em", fontWeight: "420" }],
+				sm: ["14px", { lineHeight: "1.15", letterSpacing: "0.02em", fontWeight: "420" }],
+				base: ["15px", { lineHeight: "1.15", letterSpacing: "0.02em", fontWeight: "420" }],
+				lg: ["17px", { lineHeight: "1.15", letterSpacing: "0.02em", fontWeight: "400" }],
+				xl: ["19px", { lineHeight: "1.15", letterSpacing: "0.01em", fontWeight: "400" }],
+				"2xl": [
+					"21px",
+					{ lineHeight: "1.15", letterSpacing: "0.01em", fontWeight: "400" },
+				],
+				"3xl": [
+					"25px",
+					{ lineHeight: "1.15", letterSpacing: "0.005em", fontWeight: "400" },
+				],
+			},
+		},
+	},
 	plugins: [],
 };


### PR DESCRIPTION
## Summary
- Increase panel font sizes and horizontal padding for readability, especially in sidebar (half-screen) mode
- Default the panel to fullscreen on open; remember the last fullscreen/half-screen preference
- Restore the panel's open state, size, and active session after a page refresh