### PR TITLE
feat: show tool calls immediately while streaming

### DIFF
--- a/flow/api/api.py
+++ b/flow/api/api.py
@@ -161,13 +161,7 @@ def _event_to_dict(event: Event) -> dict[str, Any]:
 	if isinstance(event, ToolStarted):
 		return {"type": "tool_started", "id": event.id, "name": event.name, "arguments": event.arguments}
 	if isinstance(event, ToolEnded):
-		return {
-			"type": "tool_ended",
-			"id": event.id,
-			"name": event.name,
-			"result": event.result,
-			"arguments": event.arguments,
-		}
+		return {"type": "tool_ended", "id": event.id, "name": event.name, "result": event.result}
 	if isinstance(event, RunStarted):
 		return {"type": "run_started", "name": event.name, "session": event.session}
 	if isinstance(event, Error):

--- a/flow/api/api.py
+++ b/flow/api/api.py
@@ -161,7 +161,13 @@ def _event_to_dict(event: Event) -> dict[str, Any]:
 	if isinstance(event, ToolStarted):
 		return {"type": "tool_started", "id": event.id, "name": event.name, "arguments": event.arguments}
 	if isinstance(event, ToolEnded):
-		return {"type": "tool_ended", "id": event.id, "name": event.name, "result": event.result}
+		return {
+			"type": "tool_ended",
+			"id": event.id,
+			"name": event.name,
+			"result": event.result,
+			"arguments": event.arguments,
+		}
 	if isinstance(event, RunStarted):
 		return {"type": "run_started", "name": event.name, "session": event.session}
 	if isinstance(event, Error):

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -8,7 +8,7 @@ from collections.abc import Generator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from flow.lib.model import ChatResponse, Model, ToolCall
+from flow.lib.model import ChatResponse, Model, ToolCall, ToolCallBegin
 from flow.lib.tool import Tool
 
 if TYPE_CHECKING:
@@ -56,7 +56,9 @@ class TextChunk:
 
 @dataclass
 class ToolStarted:
-	"""A tool call is about to execute. Lets the UI render a 'thinking' indicator."""
+	"""A tool call is about to execute. Lets the UI render a 'thinking' indicator. Emitted as soon
+	as the model starts streaming the call, so `arguments` may still be empty at that point — the
+	full arguments arrive on the matching ToolEnded."""
 
 	id: str
 	name: str
@@ -65,11 +67,13 @@ class ToolStarted:
 
 @dataclass
 class ToolEnded:
-	"""A tool call finished. `result` is the JSON-serialized return value."""
+	"""A tool call finished. `result` is the JSON-serialized return value; `arguments` are the
+	final parsed arguments (backfills a ToolStarted that fired before they finished streaming)."""
 
 	id: str
 	name: str
 	result: str
+	arguments: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -282,9 +286,17 @@ class Agent:
 
 		for iteration in range(1, self.max_iterations + 1):
 			chunks = self.model.chat(messages, tools=tool_schemas, stream=True)
+			# Tool calls are announced mid-stream (ToolCallBegin) so the UI shows the tool the moment
+			# the model starts it.
+			announced: set[str] = set()
 			try:
 				while True:
-					yield TextChunk(text=next(chunks))
+					item = next(chunks)
+					if isinstance(item, ToolCallBegin):
+						announced.add(item.id)
+						yield ToolStarted(id=item.id, name=item.name, arguments={})
+					else:
+						yield TextChunk(text=item)
 			except StopIteration as e:
 				response = e.value
 			_accumulate_usage(usage_total, response.usage)
@@ -304,18 +316,19 @@ class Agent:
 
 			questions: list[Question] = []
 			for call in response.tool_calls:
-				yield ToolStarted(id=call.id, name=call.name, arguments=call.arguments)
+				if call.id not in announced:
+					yield ToolStarted(id=call.id, name=call.name, arguments=call.arguments)
 				result = self._invoke(call)
 				if isinstance(result, Question):
 					result.key = call.id
 					questions.append(result)
-					yield ToolEnded(id=call.id, name=call.name, result="")
+					yield ToolEnded(id=call.id, name=call.name, result="", arguments=call.arguments)
 					continue
 
 				executed_calls.append(call)
 				serialized = _serialize_tool_result(result)
 				messages.append({"role": "tool", "tool_call_id": call.id, "content": serialized})
-				yield ToolEnded(id=call.id, name=call.name, result=serialized)
+				yield ToolEnded(id=call.id, name=call.name, result=serialized, arguments=call.arguments)
 
 			if questions:
 				yield Done(

--- a/flow/lib/agent.py
+++ b/flow/lib/agent.py
@@ -67,13 +67,11 @@ class ToolStarted:
 
 @dataclass
 class ToolEnded:
-	"""A tool call finished. `result` is the JSON-serialized return value; `arguments` are the
-	final parsed arguments (backfills a ToolStarted that fired before they finished streaming)."""
+	"""A tool call finished. `result` is the JSON-serialized return value."""
 
 	id: str
 	name: str
 	result: str
-	arguments: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -287,13 +285,11 @@ class Agent:
 		for iteration in range(1, self.max_iterations + 1):
 			chunks = self.model.chat(messages, tools=tool_schemas, stream=True)
 			# Tool calls are announced mid-stream (ToolCallBegin) so the UI shows the tool the moment
-			# the model starts it.
-			announced: set[str] = set()
+			# the model starts it, before its arguments finish streaming.
 			try:
 				while True:
 					item = next(chunks)
 					if isinstance(item, ToolCallBegin):
-						announced.add(item.id)
 						yield ToolStarted(id=item.id, name=item.name, arguments={})
 					else:
 						yield TextChunk(text=item)
@@ -316,19 +312,20 @@ class Agent:
 
 			questions: list[Question] = []
 			for call in response.tool_calls:
-				if call.id not in announced:
-					yield ToolStarted(id=call.id, name=call.name, arguments=call.arguments)
+				# Re-announce with the full arguments now that they've finished streaming, before the
+				# tool runs — so the UI shows the arguments during execution, not only with the result.
+				yield ToolStarted(id=call.id, name=call.name, arguments=call.arguments)
 				result = self._invoke(call)
 				if isinstance(result, Question):
 					result.key = call.id
 					questions.append(result)
-					yield ToolEnded(id=call.id, name=call.name, result="", arguments=call.arguments)
+					yield ToolEnded(id=call.id, name=call.name, result="")
 					continue
 
 				executed_calls.append(call)
 				serialized = _serialize_tool_result(result)
 				messages.append({"role": "tool", "tool_call_id": call.id, "content": serialized})
-				yield ToolEnded(id=call.id, name=call.name, result=serialized, arguments=call.arguments)
+				yield ToolEnded(id=call.id, name=call.name, result=serialized)
 
 			if questions:
 				yield Done(

--- a/flow/lib/model.py
+++ b/flow/lib/model.py
@@ -24,6 +24,15 @@ class ToolCall:
 
 
 @dataclass
+class ToolCallBegin:
+	"""Streamed marker: the model has started emitting a tool call (name known, arguments still
+	streaming). Lets the UI show the tool immediately instead of after the full arguments arrive."""
+
+	id: str
+	name: str
+
+
+@dataclass
 class ChatResponse:
 	content: str | None
 	tool_calls: list[ToolCall] = field(default_factory=list)
@@ -126,10 +135,12 @@ def resolve_provider_credentials(model_id: str) -> dict[str, Any]:
 	}
 
 
-def _consume_stream(chunks: Any) -> Generator[str, None, ChatResponse]:
-	"""Yield text deltas from a litellm stream; return the assembled ChatResponse at the end."""
+def _consume_stream(chunks: Any) -> Generator[str | ToolCallBegin, None, ChatResponse]:
+	"""Yield text deltas (and a ToolCallBegin the moment each tool call's name is known) from a
+	litellm stream; return the assembled ChatResponse at the end."""
 	content_parts: list[str] = []
 	tool_calls_acc: dict[int, dict[str, str]] = {}
+	announced: set[int] = set()
 	usage: dict[str, int] = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 	finish_reason: str | None = None
 
@@ -144,7 +155,11 @@ def _consume_stream(chunks: Any) -> Generator[str, None, ChatResponse]:
 					content_parts.append(text)
 					yield text
 				for tc_delta in _attr(delta, "tool_calls") or []:
-					_accumulate_tool_call(tool_calls_acc, tc_delta)
+					index = _accumulate_tool_call(tool_calls_acc, tc_delta)
+					slot = tool_calls_acc[index]
+					if index not in announced and slot["id"] and slot["name"]:
+						announced.add(index)
+						yield ToolCallBegin(id=slot["id"], name=slot["name"])
 			reason = _attr(choice, "finish_reason")
 			if reason:
 				finish_reason = reason
@@ -165,7 +180,7 @@ def _consume_stream(chunks: Any) -> Generator[str, None, ChatResponse]:
 	)
 
 
-def _accumulate_tool_call(acc: dict[int, dict[str, str]], delta: Any) -> None:
+def _accumulate_tool_call(acc: dict[int, dict[str, str]], delta: Any) -> int:
 	index = _attr(delta, "index", 0) or 0
 	slot = acc.setdefault(index, {"id": "", "name": "", "arguments": ""})
 	call_id = _attr(delta, "id")
@@ -179,6 +194,7 @@ def _accumulate_tool_call(acc: dict[int, dict[str, str]], delta: Any) -> None:
 		args = _attr(function, "arguments")
 		if args:
 			slot["arguments"] += args
+	return index
 
 
 def _finalize_tool_calls(acc: dict[int, dict[str, str]]) -> list[ToolCall]:

--- a/flow/tests/test_ai_model.py
+++ b/flow/tests/test_ai_model.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from frappe.tests import UnitTestCase
 
-from flow.lib.model import ChatResponse, Model, ToolCall
+from flow.lib.model import ChatResponse, Model, ToolCall, ToolCallBegin
 
 
 def _fake_response(content=None, tool_calls=None, finish_reason="stop", usage=None):
@@ -179,7 +179,8 @@ class TestModel(UnitTestCase):
 		m = Model(model_id="openai/gpt-4.1", api_key="sk-test")
 		yielded, response = _drain(m.chat([{"role": "user", "content": "hi"}], stream=True))
 
-		self.assertEqual(yielded, [])
+		# The call is announced mid-stream the moment its id+name are known.
+		self.assertEqual(yielded, [ToolCallBegin(id="call_a", name="add")])
 		self.assertEqual(len(response.tool_calls), 1)
 		call = response.tool_calls[0]
 		self.assertIsInstance(call, ToolCall)

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -365,12 +365,17 @@ function handleEvent(event, msg) {
 			appendText(msg, event.delta);
 			requestScroll();
 			break;
-		case "tool_started":
-			msg.parts.push(makeToolPart(event.id, event.name, event.arguments));
+		case "tool_started": {
+			// Fired twice: once mid-stream (no args yet), then again with the full arguments before
+			// the tool runs. Create the card on the first, fill its arguments on the second.
+			const part = msg.parts.find((p) => p.type === "tool" && p.id === event.id);
+			if (part) part.arguments = event.arguments;
+			else msg.parts.push(makeToolPart(event.id, event.name, event.arguments));
 			requestScroll();
 			break;
+		}
 		case "tool_ended":
-			setToolResult(msg, event.id, event.result, event.arguments);
+			setToolResult(msg, event.id, event.result);
 			requestScroll();
 			break;
 		case "done":
@@ -402,12 +407,10 @@ const makeToolPart = (id, name, args) => ({
 	approval: null,
 });
 
-// `args` backfills a tool part announced mid-stream, before its arguments finished streaming.
-function setToolResult(msg, id, result, args) {
+function setToolResult(msg, id, result) {
 	const part = msg.parts.find((p) => p.type === "tool" && p.id === id);
 	if (!part) return;
 	part.result = result;
-	if (args && Object.keys(args).length) part.arguments = args;
 	// On reload the live approval state is gone; recover it from the persisted
 	// confirmation result so the "Denied"/"Changes requested" badge survives. Gated on
 	// the tool being a confirmation tool so a regular tool whose result happens to carry

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -370,7 +370,7 @@ function handleEvent(event, msg) {
 			requestScroll();
 			break;
 		case "tool_ended":
-			setToolResult(msg, event.id, event.result);
+			setToolResult(msg, event.id, event.result, event.arguments);
 			requestScroll();
 			break;
 		case "done":
@@ -402,10 +402,12 @@ const makeToolPart = (id, name, args) => ({
 	approval: null,
 });
 
-function setToolResult(msg, id, result) {
+// `args` backfills a tool part announced mid-stream, before its arguments finished streaming.
+function setToolResult(msg, id, result, args) {
 	const part = msg.parts.find((p) => p.type === "tool" && p.id === id);
 	if (!part) return;
 	part.result = result;
+	if (args && Object.keys(args).length) part.arguments = args;
 	// On reload the live approval state is gone; recover it from the persisted
 	// confirmation result so the "Denied"/"Changes requested" badge survives. Gated on
 	// the tool being a confirmation tool so a regular tool whose result happens to carry


### PR DESCRIPTION
Tool cards used to appear only after the model finished streaming a call's arguments — a multi-second silent gap after a text block for calls with large arguments.

- Model layer emits a `ToolCallBegin` marker the moment a call's name is known mid-stream.
- The agent surfaces `ToolStarted` immediately (name only), then re-emits it with the full arguments once they finish streaming, before the tool runs — so arguments show during execution, not only with the result.
- Frontend `tool_started` upserts the card (create, then fill args).