### PR TITLE
feat: show plain-English intent for execute tool confirmations

### DIFF
--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -146,10 +146,15 @@ search_knowledge = bind_search_knowledge([])
 
 @tool(
 	requires_confirmation=True,
-	confirm_prompt=lambda args: f"Run this Python:\n\n{args.get('code', '')}",
+	confirm_prompt=lambda args: (
+		f"{args.get('description') or 'Run Python code'}:\n\n{args.get('code', '')}"
+	),
 )
-def execute(code: str) -> Any:
+def execute(code: str, description: str) -> Any:
 	"""Run Python in a permission-respecting sandbox for computation, emails, or multi-record work.
+
+	`description` is one short, plain-English sentence stating what this code does, for a
+	non-technical user who approves it — e.g. "Count open ToDos". Describe the intent, not the code.
 
 	Do NOT write `import` statements — imports are blocked and the whole script fails. `frappe`
 	and `frappe.utils` are already in scope; everything you can use is listed below, so never

--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -150,7 +150,7 @@ search_knowledge = bind_search_knowledge([])
 		f"{args.get('description') or 'Run Python code'}:\n\n{args.get('code', '')}"
 	),
 )
-def execute(code: str, description: str) -> Any:
+def execute(code: str, description: str = "") -> Any:
 	"""Run Python in a permission-respecting sandbox for computation, emails, or multi-record work.
 
 	`description` is one short, plain-English sentence stating what this code does, for a

--- a/frontend/src/components/ConfirmCard.vue
+++ b/frontend/src/components/ConfirmCard.vue
@@ -2,7 +2,7 @@
 import { ref, computed, nextTick } from "vue";
 import { Button, FeatherIcon } from "@/lib/ui";
 import ArgsView from "./ArgsView.vue";
-import { confirmTitle, hasArgs } from "@/lib/toolMeta";
+import { confirmTitle, hasArgs, parseArgs } from "@/lib/toolMeta";
 import { __ } from "@/lib/translate";
 
 const props = defineProps({
@@ -24,7 +24,13 @@ const danger = computed(() => Boolean(confirm.value?.danger));
 const body = computed(() =>
 	props.tool ? "" : props.question.prompt.split("\n\n").slice(1).join("\n\n").trim()
 );
-const showArgs = computed(() => Boolean(props.tool) && hasArgs(props.tool.arguments));
+// execute's description becomes the title, so drop it from the args shown below.
+const displayArgs = computed(() => {
+	if (props.tool?.name !== "execute") return props.tool?.arguments;
+	const { description, ...rest } = parseArgs(props.tool.arguments);
+	return rest;
+});
+const showArgs = computed(() => Boolean(props.tool) && hasArgs(displayArgs.value));
 const answered = computed(() => props.question._answer !== undefined);
 
 function pick(option) {
@@ -61,7 +67,7 @@ function sendOther() {
 		</div>
 
 		<div v-if="showArgs" class="mt-2.5">
-			<ArgsView :arguments="tool.arguments" />
+			<ArgsView :arguments="displayArgs" />
 		</div>
 		<pre v-else-if="body" class="flow-confirm-body">{{ body }}</pre>
 

--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -150,6 +150,8 @@ export function confirmTitle(name, args) {
 			humanize(a.action),
 			doctype ? `${count(a.names)} ${doctype}` : __("records"),
 		]);
-	else if (name === "execute") title = __("Run Python code");
+	else if (name === "execute")
+		title =
+			(typeof a.description === "string" && a.description.trim()) || __("Run Python code");
 	return { title: title || toolLabel(name), danger: name === "delete" };
 }


### PR DESCRIPTION
## Summary
The execute tool's approval card showed raw Python code with no explanation, which non-technical users can't parse before approving. The model now supplies a one-line `description` of intent, shown as the confirm title; the code stays fully visible below.
