### PR TITLE
fix: keep execute description required so the model always supplies intent

### DIFF
--- a/flow/tools/builtins.py
+++ b/flow/tools/builtins.py
@@ -150,7 +150,7 @@ search_knowledge = bind_search_knowledge([])
 		f"{args.get('description') or 'Run Python code'}:\n\n{args.get('code', '')}"
 	),
 )
-def execute(code: str, description: str = "") -> Any:
+def execute(code: str, description: str) -> Any:
 	"""Run Python in a permission-respecting sandbox for computation, emails, or multi-record work.
 
 	`description` is one short, plain-English sentence stating what this code does, for a


### PR DESCRIPTION
## Summary
Reverts the `description=""` default merged in #74. A default drops `description` from the tool's `required` schema, telling the model it's optional — so it more often skips the intent and the confirm card falls back to the generic "Run Python code". Keeping it required ensures the model always supplies a plain-English intent. The `confirm_prompt` `.get()` guard already covers the only path where a missing value mattered.
