### PR TITLE
fix: make Flow installable on Frappe Cloud and v16

### DIFF
--- a/flow/hooks.py
+++ b/flow/hooks.py
@@ -3,7 +3,7 @@ app_title = "Flow"
 app_publisher = "Shrihari Mahabal"
 app_description = "Frappe Flow — native AI agents, tools, and triggers for Frappe"
 app_email = "shriharimahabal08@gmail.com"
-app_license = "mit"
+app_license = "agpl-3.0"
 
 export_python_type_annotations = True
 

--- a/flow/tests/test_ai_builtins.py
+++ b/flow/tests/test_ai_builtins.py
@@ -100,18 +100,18 @@ class TestExecute(IntegrationTestCase):
 		frappe.db.rollback()
 
 	def test_returns_result_variable(self):
-		self.assertEqual(execute(code="result = 1 + 1"), 2)
+		self.assertEqual(execute(code="result = 1 + 1", description="Add two numbers"), 2)
 
 	def test_no_result_returns_none(self):
-		self.assertIsNone(execute(code="x = 5"))
+		self.assertIsNone(execute(code="x = 5", description="Set a variable"))
 
 	def test_can_read_via_frappe(self):
-		count = execute(code="result = frappe.db.count('DocType')")
+		count = execute(code="result = frappe.db.count('DocType')", description="Count doctypes")
 		self.assertIsInstance(count, int)
 
 	def test_imports_are_blocked(self):
 		with self.assertRaises(Exception):
-			execute(code="import os\nresult = os.getcwd()")
+			execute(code="import os\nresult = os.getcwd()", description="Get working directory")
 
 
 class TestCreate(IntegrationTestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "AGPL-3.0-or-later"
 dynamic = ["version"]
 dependencies = [
-    "litellm==1.83.7",
+    "litellm>=1.83.0,<1.83.8",
     "lancedb<1,>=0.33",
     "python-docx<2,>=1.1",
     "pdfplumber<1,>=0.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "AGPL-3.0-or-later"
 dynamic = ["version"]
 dependencies = [
-    "litellm<2,>=1.83.0",
+    "litellm==1.83.7",
     "lancedb<1,>=0.33",
     "python-docx<2,>=1.1",
     "pdfplumber<1,>=0.11",
@@ -21,13 +21,16 @@ dependencies = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0-dev,<18.0.0"
+
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"
 
 # These apt dependencies will be installed from Ubuntu repositories when you host your app on Frappe Cloud
 [deploy.dependencies.apt]
-packages = []
+packages = ["libgl1", "libglib2.0-0"]
 
 [tool.ruff]
 line-length = 110


### PR DESCRIPTION
Fixes #76 — Flow could not be installed on Frappe Cloud.

- Add `[tool.bench.frappe-dependencies]` (`frappe = ">=16.0.0-dev,<18.0.0"`) so FC/bench recognize a compatible Frappe version. Verified Flow's full API surface works on both v16 and v17.
- Pin `litellm==1.83.7` — the last release supporting Python 3.14. Newer versions drop 3.14 and 1.92.0 ships a Rust extension with no cp314 wheel, breaking source builds on any fresh 3.14 bench (including FC).
- Add apt deps `libgl1`, `libglib2.0-0` for rapidocr's opencv on headless FC.
- Correct `app_license` to `agpl-3.0` to match pyproject/license.txt.