### PR TITLE
fix: render multi-line and long text as a code block

### DIFF
--- a/frontend/src/components/ActivityStep.vue
+++ b/frontend/src/components/ActivityStep.vue
@@ -3,7 +3,7 @@ import { computed, ref } from "vue";
 import { FeatherIcon, Spinner } from "@/lib/ui";
 import ActivityLabel from "./ActivityLabel.vue";
 import ArgsView from "./ArgsView.vue";
-import { toolLabel, toolContext, hasArgs } from "@/lib/toolMeta";
+import { toolLabel, toolContext, hasArgs, blockKeysFor } from "@/lib/toolMeta";
 
 // One timeline step. A fixed-width gutter holds the dot; connector lines are
 // flex-1 fillers above and below it, so they auto-centre on the dot and meet the
@@ -21,6 +21,7 @@ const active = computed(
 const label = computed(() => toolLabel(props.part.name));
 const context = computed(() => toolContext(props.part.arguments));
 const expandable = computed(() => hasArgs(props.part.arguments));
+const blockKeys = computed(() => blockKeysFor(props.part.name));
 
 const open = ref(false);
 function toggle() {
@@ -73,7 +74,7 @@ function toggle() {
 				<span class="w-px" :class="{ 'bg-surface-gray-3': !last }"></span>
 			</div>
 			<div class="min-w-0 flex-1 pb-2">
-				<ArgsView :arguments="part.arguments" />
+				<ArgsView :arguments="part.arguments" :block-keys="blockKeys" />
 			</div>
 		</div>
 	</div>

--- a/frontend/src/components/ArgValue.vue
+++ b/frontend/src/components/ArgValue.vue
@@ -16,7 +16,7 @@ const props = defineProps({
 });
 
 const kindFor = (k, v) => {
-	if (typeof v === "string" && v && (k === "code" || props.blockKeys.has(k))) return "code";
+	if (typeof v === "string" && v && props.blockKeys.has(k)) return "code";
 	return argKind(v);
 };
 

--- a/frontend/src/components/ArgValue.vue
+++ b/frontend/src/components/ArgValue.vue
@@ -2,30 +2,27 @@
 import { computed } from "vue";
 import CodeBlock from "./CodeBlock.vue";
 import ChipList from "./ChipList.vue";
-import ClampText from "./ClampText.vue";
 import RecordsList from "./RecordsList.vue";
-import { humanize, argKind, formatScalar, isLongText } from "@/lib/toolMeta";
+import { humanize, argKind, formatScalar } from "@/lib/toolMeta";
 
-// Fields render in one bordered table: single values as two-column rows, code and
-// long text as full-width rows (label on top, block below) so they keep their
-// place in the field order. Collections (lists, records, nested objects) render
-// as full-width sections beneath. `blockKeys` forces a key to the text form so a
-// field looks the same across sibling records.
+// Fields render in one bordered table: single values as two-column rows, block
+// text (code, long, or multi-line) as full-width rows (label on top, code block
+// below) so they keep their place in the field order. Collections (lists, records,
+// nested objects) render as full-width sections beneath. `blockKeys` forces a key
+// to the block form so a field looks the same across sibling records.
 const props = defineProps({
 	value: { type: Object, required: true },
 	blockKeys: { type: Object, default: () => new Set() },
 });
 
 const kindFor = (k, v) => {
-	const base = k === "code" && typeof v === "string" && v ? "code" : argKind(v);
-	if (base === "code") return "code";
-	if (typeof v === "string" && v && (props.blockKeys.has(k) || isLongText(v))) return "text";
-	return base;
+	if (typeof v === "string" && v && (k === "code" || props.blockKeys.has(k))) return "code";
+	return argKind(v);
 };
 
-// In the table: two-column single values + full-span code/text. Below: collections.
-const TABLE = new Set(["scalar", "empty", "tuple", "code", "text"]);
-const isFull = (kind) => kind === "code" || kind === "text";
+// In the table: two-column single values + full-span block text. Below: collections.
+const TABLE = new Set(["scalar", "empty", "tuple", "code"]);
+const isFull = (kind) => kind === "code";
 
 const entries = computed(() =>
 	Object.entries(props.value).map(([key, value]) => ({ key, value, kind: kindFor(key, value) }))
@@ -53,8 +50,7 @@ const tupleValues = (v) => (Array.isArray(v[1]) ? v[1] : [v[1]]).map(formatScala
 					>
 						{{ humanize(row.key) }}
 					</div>
-					<CodeBlock v-if="row.kind === 'code'" :code="String(row.value)" />
-					<ClampText v-else :text="String(row.value)" />
+					<CodeBlock :code="String(row.value)" />
 				</div>
 				<template v-else>
 					<div

--- a/frontend/src/components/ArgsView.vue
+++ b/frontend/src/components/ArgsView.vue
@@ -6,7 +6,10 @@ import CodeBlock from "./CodeBlock.vue";
 
 // Entry point for a tool call's arguments: parses once, renders by shape.
 // Unparseable JSON falls back to the raw payload so it's never hidden.
-const props = defineProps({ arguments: { default: null } });
+const props = defineProps({
+	arguments: { default: null },
+	blockKeys: { type: Object, default: () => new Set() },
+});
 
 const parsed = computed(() => parseArgs(props.arguments));
 const hasFields = computed(() => Object.keys(parsed.value).length > 0);
@@ -14,6 +17,6 @@ const raw = computed(() => (hasFields.value ? "" : rawArgs(props.arguments)));
 </script>
 
 <template>
-	<ArgValue v-if="hasFields" :value="parsed" />
+	<ArgValue v-if="hasFields" :value="parsed" :block-keys="blockKeys" />
 	<CodeBlock v-else-if="raw" :code="raw" />
 </template>

--- a/frontend/src/components/ConfirmCard.vue
+++ b/frontend/src/components/ConfirmCard.vue
@@ -2,7 +2,7 @@
 import { ref, computed, nextTick } from "vue";
 import { Button, FeatherIcon } from "@/lib/ui";
 import ArgsView from "./ArgsView.vue";
-import { confirmTitle, hasArgs, parseArgs } from "@/lib/toolMeta";
+import { confirmTitle, hasArgs, parseArgs, blockKeysFor } from "@/lib/toolMeta";
 import { __ } from "@/lib/translate";
 
 const props = defineProps({
@@ -31,6 +31,7 @@ const displayArgs = computed(() => {
 	return rest;
 });
 const showArgs = computed(() => Boolean(props.tool) && hasArgs(displayArgs.value));
+const blockKeys = computed(() => blockKeysFor(props.tool?.name));
 const answered = computed(() => props.question._answer !== undefined);
 
 function pick(option) {
@@ -67,7 +68,7 @@ function sendOther() {
 		</div>
 
 		<div v-if="showArgs" class="mt-2.5">
-			<ArgsView :arguments="displayArgs" />
+			<ArgsView :arguments="displayArgs" :block-keys="blockKeys" />
 		</div>
 		<pre v-else-if="body" class="flow-confirm-body">{{ body }}</pre>
 

--- a/frontend/src/components/RecordsList.vue
+++ b/frontend/src/components/RecordsList.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed } from "vue";
 import ArgValue from "./ArgValue.vue";
-import { formatScalar, recordLabelKey, isLongText } from "@/lib/toolMeta";
+import { formatScalar, recordLabelKey, isBlockText } from "@/lib/toolMeta";
 import { __ } from "@/lib/translate";
 
 // Records laid flat: numbered, title first, every field visible right away.
@@ -27,14 +27,14 @@ const fieldOrder = computed(() => {
 	return order;
 });
 
-// Fields long in any record render as a text block in every record, so a field
-// looks the same across records regardless of one record's shorter value.
+// Fields that are block text in any record render as a code block in every record,
+// so a field looks the same across records regardless of one record's shorter value.
 const blockKeys = computed(() => {
 	const keys = new Set();
 	for (const rec of props.records) {
 		if (!isObj(rec)) continue;
 		for (const [k, v] of Object.entries(rec)) {
-			if (k !== labelKey.value && isLongText(v)) keys.add(k);
+			if (k !== labelKey.value && isBlockText(v)) keys.add(k);
 		}
 	}
 	return keys;

--- a/frontend/src/components/UserMessage.vue
+++ b/frontend/src/components/UserMessage.vue
@@ -18,7 +18,7 @@ defineProps({
 			/>
 		</div>
 		<div
-			class="max-w-[88%] whitespace-pre-wrap break-words rounded-2xl rounded-br-md bg-surface-gray-2 px-3.5 py-2.5 text-[length:var(--text-base)] font-normal leading-relaxed text-ink-gray-9"
+			class="max-w-[88%] whitespace-pre-wrap break-words rounded-2xl bg-surface-gray-2 px-3.5 py-2.5 text-[length:var(--text-base)] font-normal leading-relaxed text-ink-gray-9"
 		>
 			{{ content }}
 		</div>

--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -67,10 +67,11 @@ export function formatScalar(v) {
 	return String(v);
 }
 
-// Single-line text long enough to clamp behind "Show more" rather than inline it.
+// Text that must render as a full-width code block rather than inline: multi-line
+// or long. Anything with a newline, or a single line past the limit.
 const LONG_TEXT_LIMIT = 120;
-export const isLongText = (v) =>
-	typeof v === "string" && !v.includes("\n") && v.length > LONG_TEXT_LIMIT;
+export const isBlockText = (v) =>
+	typeof v === "string" && (v.includes("\n") || v.length > LONG_TEXT_LIMIT);
 
 const FILTER_OPERATORS = new Set([
 	"=",
@@ -103,7 +104,7 @@ export function argKind(v) {
 		return v.every(isScalar) ? "list" : "records";
 	}
 	if (typeof v === "object") return Object.keys(v).length ? "object" : "empty";
-	if (typeof v === "string" && v.includes("\n")) return "code";
+	if (isBlockText(v)) return "code";
 	return "scalar";
 }
 
@@ -115,9 +116,11 @@ export function recordLabelKey(records) {
 	const first = records.find((r) => r && typeof r === "object" && !Array.isArray(r));
 	if (!first) return null;
 	for (const key of TITLE_KEYS) {
-		if (typeof first[key] === "string" && first[key]) return key;
+		if (typeof first[key] === "string" && first[key] && !isBlockText(first[key])) return key;
 	}
-	const entry = Object.entries(first).find(([, v]) => isScalar(v) && v !== null && v !== "");
+	const entry = Object.entries(first).find(
+		([, v]) => isScalar(v) && v !== null && v !== "" && !isBlockText(v)
+	);
 	return entry ? entry[0] : null;
 }
 

--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -124,6 +124,11 @@ export function recordLabelKey(records) {
 	return entry ? entry[0] : null;
 }
 
+// Args to always render as a code block regardless of content, keyed by tool name.
+// execute's "code" is Python source even when short/single-line.
+const CODE_ARG_KEYS = { execute: new Set(["code"]) };
+export const blockKeysFor = (name) => CODE_ARG_KEYS[name] || new Set();
+
 // Muted suffix that distinguishes a step (which doctype / search / action).
 export function toolContext(args) {
 	const a = parseArgs(args);


### PR DESCRIPTION
Multi-line/long string fields were being truncated to one line when picked as a record's title, instead of rendering as a code block.
Only force code-block rendering for execute's code arg