### PR TITLE
Readable Flow Session transcript, Flow Run tweaks

### DIFF
--- a/flow/flow/doctype/flow_run/flow_run.js
+++ b/flow/flow/doctype/flow_run/flow_run.js
@@ -3,6 +3,14 @@
 
 frappe.ui.form.on("Flow Run", {
 	refresh(frm) {
+		if (frm.doc.output) {
+			const trimmed = frm.doc.output.trim();
+			if (trimmed !== frm.doc.output) {
+				frm.doc.output = trimmed;
+				frm.refresh_field("output");
+			}
+		}
+
 		const parse = (value) => {
 			if (!value) return null;
 			if (typeof value === "object") return value;

--- a/flow/flow/doctype/flow_run/flow_run.json
+++ b/flow/flow/doctype/flow_run/flow_run.json
@@ -103,7 +103,8 @@
    "description": "Original user input that started the run.",
    "fieldname": "input",
    "fieldtype": "Long Text",
-   "label": "Input"
+   "label": "Input",
+   "read_only": 1
   },
   {
    "description": "Final assistant message when the run completes.",

--- a/flow/flow/doctype/flow_session/flow_session.js
+++ b/flow/flow/doctype/flow_session/flow_session.js
@@ -2,6 +2,36 @@
 // License: MIT. See LICENSE
 
 frappe.ui.form.on("Flow Session", {
-	// refresh(frm) {
-	// },
+	refresh(frm) {
+		const parse = (v) => {
+			try {
+				return JSON.parse(v);
+			} catch {
+				return null;
+			}
+		};
+		// Pretty-print JSON strings; leave plain text untouched.
+		const pretty = (v) => {
+			const p = parse(v);
+			return p !== null ? JSON.stringify(p, null, 2) : v;
+		};
+
+		const items = (frm.doc.messages || []).map((r) => {
+			const item = {
+				role: r.role,
+				content: r.role === "tool" ? null : (r.content || "").trim() || null,
+				calls: [],
+			};
+			if (r.role === "tool") item.output = pretty(r.content);
+			for (const c of parse(r.tool_calls) || []) {
+				const fn = c.function || c;
+				item.calls.push({ name: fn.name, args: pretty(fn.arguments) });
+			}
+			return item;
+		});
+
+		frm.get_field("transcript_html").$wrapper.html(
+			frappe.render_template("flow_session_transcript", { items })
+		);
+	},
 });

--- a/flow/flow/doctype/flow_session/flow_session.json
+++ b/flow/flow/doctype/flow_session/flow_session.json
@@ -10,6 +10,7 @@
   "model",
   "source",
   "section_break_transcript",
+  "transcript_html",
   "messages",
   "attachments"
  ],
@@ -56,9 +57,15 @@
    "label": "Transcript"
   },
   {
+   "fieldname": "transcript_html",
+   "fieldtype": "HTML",
+   "label": "Transcript"
+  },
+  {
    "description": "Full chat transcript across all runs in this conversation.",
    "fieldname": "messages",
    "fieldtype": "Table",
+   "hidden": 1,
    "label": "Messages",
    "options": "Flow Session Message",
    "read_only": 1

--- a/flow/flow/doctype/flow_session/flow_session_transcript.html
+++ b/flow/flow/doctype/flow_session/flow_session_transcript.html
@@ -1,0 +1,43 @@
+<style>
+.flow-transcript { max-width: 900px; position: relative; }
+.flow-transcript::before { content: ""; position: absolute; top: 0; bottom: 0; left: 90px; width: 1px; background: var(--border-color); }
+.flow-transcript .msg { display: flex; padding: 14px 0; border-top: 1px solid var(--border-color); }
+.flow-transcript .msg:first-child { border-top: none; }
+.flow-transcript .role { flex: 0 0 90px; font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: .04em; color: var(--text-muted); padding-top: 1px; }
+.flow-transcript .msg-user .role { color: var(--text-color); }
+.flow-transcript .body { flex: 1 1 auto; min-width: 0; padding-left: 20px; }
+.flow-transcript .text { white-space: pre-wrap; word-break: break-word; color: var(--text-color); line-height: 1.55; }
+.flow-transcript .calls { margin-top: 10px; display: flex; flex-direction: column; gap: 10px; }
+.flow-transcript .calls:first-child { margin-top: 0; }
+.flow-transcript .tname { display: inline-block; font-family: var(--font-stack-monospace, monospace); font-size: 12px; font-weight: 500; color: var(--text-color); background: var(--control-bg); border-radius: 4px; padding: 2px 7px; margin-bottom: 6px; }
+.flow-transcript pre.json { white-space: pre-wrap; word-break: break-word; font-size: 12px; line-height: 1.5; margin: 0; background: var(--control-bg); border: 1px solid var(--border-color); border-radius: 6px; padding: 9px 11px; overflow: auto; max-height: 360px; }
+.flow-transcript .empty { color: var(--text-muted); }
+</style>
+{% var esc = (v) => frappe.utils.escape_html(v == null ? "" : String(v)); %}
+<div class="flow-transcript">
+{% if !items || !items.length %}
+	<div class="empty">{{ __("No messages yet.") }}</div>
+{% endif %}
+{% for m in items %}
+	<div class="msg msg-{{ m.role }}">
+		<div class="role">{{ m.role }}</div>
+		<div class="body">
+		{% if m.role === "tool" %}
+			<pre class="json">{{ esc(m.output) }}</pre>
+		{% else %}
+			{% if m.content %}<div class="text">{{ esc(m.content) }}</div>{% endif %}
+			{% if m.calls && m.calls.length %}
+			<div class="calls">
+			{% for c in m.calls %}
+				<div class="toolcall">
+					<div class="tname">{{ esc(c.name) }}</div>
+					<pre class="json">{{ esc(c.args) }}</pre>
+				</div>
+			{% endfor %}
+			</div>
+			{% endif %}
+		{% endif %}
+		</div>
+	</div>
+{% endfor %}
+</div>

--- a/flow/flow/doctype/flow_session/flow_session_transcript.html
+++ b/flow/flow/doctype/flow_session/flow_session_transcript.html
@@ -19,8 +19,8 @@
 	<div class="empty">{{ __("No messages yet.") }}</div>
 {% endif %}
 {% for m in items %}
-	<div class="msg msg-{{ m.role }}">
-		<div class="role">{{ m.role }}</div>
+	<div class="msg msg-{{ esc(m.role) }}">
+		<div class="role">{{ esc(m.role) }}</div>
 		<div class="body">
 		{% if m.role === "tool" %}
 			<pre class="json">{{ esc(m.output) }}</pre>


### PR DESCRIPTION
## Summary
- Render Flow Session's transcript as readable HTML instead of the raw messages grid, including tool calls/results as formatted JSON
- Make Flow Run's Input field read-only
- Trim whitespace from Flow Run's Output field on display