### PR TITLE
feat: show failed tool calls in activity timeline

### DIFF
--- a/frontend/src/components/ActivityGroup.vue
+++ b/frontend/src/components/ActivityGroup.vue
@@ -4,7 +4,8 @@ import { FeatherIcon } from "@/lib/ui";
 import ActivityLabel from "./ActivityLabel.vue";
 import ActivityStep from "./ActivityStep.vue";
 import ArgsView from "./ArgsView.vue";
-import { toolLabel, hasArgs } from "@/lib/toolMeta";
+import ToolError from "./ToolError.vue";
+import { toolLabel, hasArgs, toolError } from "@/lib/toolMeta";
 import { __ } from "@/lib/translate";
 
 // Tool calls as one collapsible line: running → active step's label; done → latest
@@ -27,16 +28,22 @@ const summary = computed(() => {
 	return toolLabel(props.parts[props.parts.length - 1].name);
 });
 
-// Only set on a resolved approval line.
+// A single tool call whose result is an error payload.
+const error = computed(() => (single.value ? toolError(props.parts[0].result) : null));
+
+// Only set on a resolved approval or failed line.
 const status = computed(() => {
+	if (error.value) return __("Failed");
 	const a = single.value ? props.parts[0].approval : null;
 	if (a === "denied") return __("Denied");
 	if (a === "redirected") return __("Changes requested");
 	return "";
 });
 
-// A lone step with no inputs has nothing to reveal.
-const expandable = computed(() => !single.value || hasArgs(props.parts[0].arguments));
+// A lone step reveals its inputs, or its error when it failed with none.
+const expandable = computed(
+	() => !single.value || hasArgs(props.parts[0].arguments) || Boolean(error.value)
+);
 const open = ref(false);
 function toggle() {
 	if (expandable.value) open.value = !open.value;
@@ -71,7 +78,14 @@ function toggle() {
 				v-if="open"
 				class="mb-2 mt-1.5 rounded-lg border border-outline-gray-1 px-3 py-2.5"
 			>
-				<ArgsView v-if="single" :arguments="parts[0].arguments" />
+				<template v-if="single">
+					<ArgsView :arguments="parts[0].arguments" />
+					<ToolError
+						v-if="error"
+						:message="error"
+						:class="{ 'mt-2': hasArgs(parts[0].arguments) }"
+					/>
+				</template>
 				<div v-else>
 					<ActivityStep
 						v-for="(part, i) in parts"

--- a/frontend/src/components/ActivityStep.vue
+++ b/frontend/src/components/ActivityStep.vue
@@ -3,7 +3,9 @@ import { computed, ref } from "vue";
 import { FeatherIcon, Spinner } from "@/lib/ui";
 import ActivityLabel from "./ActivityLabel.vue";
 import ArgsView from "./ArgsView.vue";
-import { toolLabel, toolContext, hasArgs, blockKeysFor } from "@/lib/toolMeta";
+import ToolError from "./ToolError.vue";
+import { toolLabel, toolContext, hasArgs, blockKeysFor, toolError } from "@/lib/toolMeta";
+import { __ } from "@/lib/translate";
 
 // One timeline step. A fixed-width gutter holds the dot; connector lines are
 // flex-1 fillers above and below it, so they auto-centre on the dot and meet the
@@ -20,7 +22,8 @@ const active = computed(
 );
 const label = computed(() => toolLabel(props.part.name));
 const context = computed(() => toolContext(props.part.arguments));
-const expandable = computed(() => hasArgs(props.part.arguments));
+const error = computed(() => toolError(props.part.result));
+const expandable = computed(() => hasArgs(props.part.arguments) || Boolean(error.value));
 const blockKeys = computed(() => blockKeysFor(props.part.name));
 
 const open = ref(false);
@@ -59,6 +62,9 @@ function toggle() {
 				<span v-if="context" class="truncate text-xs text-ink-gray-4"
 					>· {{ context }}</span
 				>
+				<span v-if="error" class="shrink-0 text-xs text-ink-gray-5"
+					>· {{ __("Failed") }}</span
+				>
 				<span class="flex-1"></span>
 				<FeatherIcon
 					v-if="expandable"
@@ -75,6 +81,11 @@ function toggle() {
 			</div>
 			<div class="min-w-0 flex-1 pb-2">
 				<ArgsView :arguments="part.arguments" :block-keys="blockKeys" />
+				<ToolError
+					v-if="error"
+					:message="error"
+					:class="{ 'mt-2': hasArgs(part.arguments) }"
+				/>
 			</div>
 		</div>
 	</div>

--- a/frontend/src/components/ToolError.vue
+++ b/frontend/src/components/ToolError.vue
@@ -1,0 +1,25 @@
+<script setup>
+// A failed tool call's error message, shown inside its dropdown.
+defineProps({ message: { type: String, required: true } });
+</script>
+
+<template>
+	<pre class="tool-error">{{ message }}</pre>
+</template>
+
+<style scoped>
+.tool-error {
+	margin: 0;
+	max-height: 320px;
+	overflow: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+	border-radius: 8px;
+	background: var(--surface-red-1);
+	padding: 8px 10px;
+	font-family: var(--font-stack-monospace, ui-monospace, monospace);
+	font-size: 12.5px;
+	line-height: 1.6;
+	color: var(--ink-red-4);
+}
+</style>

--- a/frontend/src/lib/toolMeta.js
+++ b/frontend/src/lib/toolMeta.js
@@ -58,6 +58,36 @@ export function normalizeToolName(name) {
 
 export const hasArgs = (args) => Object.keys(parseArgs(args)).length > 0 || Boolean(rawArgs(args));
 
+// The error message when a tool call wholly failed, else null. Two failure shapes:
+// a thrown tool → {error: "..."}; a bulk create/update/delete where every record
+// failed → {created|updated|deleted: [], failures: [{error}, ...]}.
+export function toolError(result) {
+	if (typeof result !== "string") return null;
+	let parsed;
+	try {
+		parsed = JSON.parse(result);
+	} catch {
+		return null; // a plain-text result, not an error payload
+	}
+	if (!parsed || typeof parsed !== "object") return null;
+	if (typeof parsed.error === "string") return parsed.error;
+
+	const failures = parsed.failures;
+	if (Array.isArray(failures) && failures.length) {
+		const succeeded = [parsed.created, parsed.updated, parsed.deleted].some(
+			(a) => Array.isArray(a) && a.length
+		);
+		if (!succeeded) {
+			const msg = failures
+				.map((f) => f && f.error)
+				.filter((e) => typeof e === "string")
+				.join("\n");
+			return msg || null;
+		}
+	}
+	return null;
+}
+
 export const isScalar = (v) => v === null || typeof v !== "object";
 
 export function formatScalar(v) {


### PR DESCRIPTION
## Summary
- Surface a `· Failed` badge (same style as `· Denied`) on tool calls whose result is an error payload, with the message shown in the dropdown
- Covers both a thrown/unknown-tool error (`{error}`) and a bulk create/update/delete where every record failed (`{failures: [...]}`, nothing in `created`/`updated`/`deleted`)