### PR TITLE
fix: keep streamed tool calls in one activity group

### DIFF
--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -475,8 +475,10 @@ function pushAssistant(pending = true) {
 
 function appendText(msg, delta) {
 	const last = msg.parts[msg.parts.length - 1];
+	// Only open a new text part on real text. A whitespace-only delta between tool calls
+	// (some models emit these) would otherwise split one activity group into two.
 	if (last && last.type === "text") last.text += delta;
-	else msg.parts.push(makeTextPart(delta));
+	else if (delta.trim()) msg.parts.push(makeTextPart(delta));
 }
 
 function failMessage(msg, error) {


### PR DESCRIPTION
Fixes tool calls fragmenting into multiple activity groups mid-stream.

Some models emit whitespace-only text deltas between tool calls. `appendText` turned each into a new text part, splitting one run of tool calls into separate `ActivityGroup`s (e.g. a sealed "Ran 5 steps" plus a stray "Finding relevant DocTypes"). It rendered correctly only after a refresh, since the blank text isn't persisted.

Fix: only open a new text part when the delta has non-whitespace content; whitespace still appends to an existing text part, so real spacing is unaffected.
