### PR TITLE
fix: don't send empty api_key to Ollama

### DIFF
--- a/flow/flow/doctype/flow_model/flow_model.py
+++ b/flow/flow/doctype/flow_model/flow_model.py
@@ -133,7 +133,7 @@ class FlowModel(Document):
 		from flow.lib.model import resolve_provider_credentials
 
 		provider_creds = resolve_provider_credentials(self.model_id)
-		api_key = self.get_password("api_key", raise_exception=False) or provider_creds.get("api_key") or ""
+		api_key = self.get_password("api_key", raise_exception=False) or provider_creds.get("api_key") or None
 		base_url = self.base_url or provider_creds.get("base_url")
 
 		kwargs = {

--- a/flow/flow/doctype/flow_provider/test_flow_provider.py
+++ b/flow/flow/doctype/flow_provider/test_flow_provider.py
@@ -76,11 +76,11 @@ class TestProviderCredentialResolution(IntegrationTestCase):
 	def test_disabled_provider_not_used(self):
 		frappe.get_doc(_provider(api_key="sk-from-provider", enabled=0)).insert()
 		m = frappe.get_doc(_model()).insert()
-		self.assertEqual(Model(m.name)._api_key, "")
+		self.assertIsNone(Model(m.name)._api_key)
 
 	def test_no_provider_row_leaves_key_empty(self):
 		m = frappe.get_doc(_model()).insert()
-		self.assertEqual(Model(m.name)._api_key, "")
+		self.assertIsNone(Model(m.name)._api_key)
 
 	def test_provider_base_url_used_when_model_has_none(self):
 		frappe.get_doc(_provider(base_url="http://gateway.local")).insert()

--- a/flow/lib/model.py
+++ b/flow/lib/model.py
@@ -73,7 +73,7 @@ class Model:
 			params = {**provider_creds["extra_params"], **(params or {})}
 
 		self.model_id = model_id
-		self._api_key = api_key or ""
+		self._api_key = api_key or None
 		self.base_url = base_url
 		self.params = params or {}
 		self.timeout = timeout
@@ -129,7 +129,7 @@ def resolve_provider_credentials(model_id: str) -> dict[str, Any]:
 		return {}
 
 	return {
-		"api_key": doc.get_password("api_key", raise_exception=False) or "",
+		"api_key": doc.get_password("api_key", raise_exception=False) or None,
 		"base_url": doc.base_url or None,
 		"extra_params": json.loads(doc.extra_params) if doc.extra_params else {},
 	}

--- a/flow/tests/test_ai_model.py
+++ b/flow/tests/test_ai_model.py
@@ -45,7 +45,7 @@ class TestModel(UnitTestCase):
 
 	def test_init_allows_empty_api_key_for_local_providers(self):
 		m = Model(model_id="ollama/llama3.1", base_url="http://localhost:11434")
-		self.assertEqual(m._api_key, "")
+		self.assertIsNone(m._api_key)
 
 	def test_init_rejects_name_with_kwargs(self):
 		with self.assertRaises(ValueError):


### PR DESCRIPTION
frappe.exceptions.ValidationError: litellm.APIConnectionError: OllamaException - Illegal header value b'Bearer '