### PR TITLE
fix: route OpenAI models through Responses API

### DIFF
--- a/flow/flow/doctype/flow_model/flow_model.json
+++ b/flow/flow/doctype/flow_model/flow_model.json
@@ -11,6 +11,7 @@
   "section_break_config",
   "provider",
   "model_id",
+  "api_style",
   "context_window",
   "api_key",
   "base_url",
@@ -51,6 +52,14 @@
    "reqd": 1
   },
   {
+   "default": "Auto",
+   "description": "API used for official OpenAI models. Auto uses Responses for direct OpenAI connections and LiteLLM defaults for custom endpoints and other providers.",
+   "fieldname": "api_style",
+   "fieldtype": "Select",
+   "label": "API Style",
+   "options": "Auto\nResponses\nChat Completions"
+  },
+  {
    "description": "Max input tokens. Auto-detected from the model on save; managed by Flow, not user-editable. 0 = unknown.",
    "fieldname": "context_window",
    "fieldtype": "Int",
@@ -86,7 +95,7 @@
   }
  ],
  "links": [],
- "modified": "2026-07-04 00:00:00.000000",
+ "modified": "2026-07-06 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Flow",
  "name": "Flow Model",

--- a/flow/flow/doctype/flow_model/flow_model.py
+++ b/flow/flow/doctype/flow_model/flow_model.py
@@ -10,6 +10,7 @@ from frappe import _
 from frappe.model.document import Document
 
 MODEL_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_\-]*\/[A-Za-z0-9][A-Za-z0-9_\-:.\/]*$")
+CONNECTION_TEST_MAX_TOKENS = 100  # Safely above provider minimums for connection probes.
 
 RESERVED_PARAM_KEYS = frozenset(
 	{"model", "api_key", "api_base", "base_url", "messages", "stream", "tools", "tool_choice"}
@@ -133,6 +134,7 @@ class FlowModel(Document):
 
 		from flow.lib.model import API_STYLE_AUTO, resolve_provider_credentials, route_model_id
 
+<<<<<<< HEAD
 		provider_creds = resolve_provider_credentials(self.model_id)
 		api_key = self.get_password("api_key", raise_exception=False) or provider_creds.get("api_key") or None
 		base_url = self.base_url or provider_creds.get("base_url")
@@ -146,6 +148,11 @@ class FlowModel(Document):
 		}
 		if base_url:
 			kwargs["api_base"] = base_url
+=======
+		model = Model(self.name)
+		kwargs = model.completion_kwargs([{"role": "user", "content": "ping"}])
+		kwargs.update(max_tokens=CONNECTION_TEST_MAX_TOKENS, timeout=15)
+>>>>>>> d2dc476 (fix: use valid Responses connection-test token limit)
 
 		try:
 			litellm.completion(**kwargs)

--- a/flow/flow/doctype/flow_model/flow_model.py
+++ b/flow/flow/doctype/flow_model/flow_model.py
@@ -26,6 +26,7 @@ class FlowModel(Document):
 		from frappe.types import DF
 
 		api_key: DF.Password | None
+		api_style: DF.Literal["Auto", "Chat Completions", "Responses"]
 		base_url: DF.Data | None
 		context_window: DF.Int
 		enabled: DF.Check
@@ -130,14 +131,14 @@ class FlowModel(Document):
 				title=_("Missing Dependency"),
 			)
 
-		from flow.lib.model import resolve_provider_credentials
+		from flow.lib.model import API_STYLE_AUTO, resolve_provider_credentials, route_model_id
 
 		provider_creds = resolve_provider_credentials(self.model_id)
 		api_key = self.get_password("api_key", raise_exception=False) or provider_creds.get("api_key") or None
 		base_url = self.base_url or provider_creds.get("base_url")
 
 		kwargs = {
-			"model": self.model_id,
+			"model": route_model_id(self.model_id, self.api_style or API_STYLE_AUTO, base_url),
 			"api_key": api_key,
 			"messages": [{"role": "user", "content": "ping"}],
 			"max_tokens": 1,

--- a/flow/flow/doctype/flow_model/test_flow_model.py
+++ b/flow/flow/doctype/flow_model/test_flow_model.py
@@ -29,6 +29,7 @@ class TestFlowModelValidation(IntegrationTestCase):
 		doc = frappe.get_doc(_model()).insert()
 
 		self.assertEqual(doc.model_id, "openai/gpt-4o-mini")
+		self.assertEqual(doc.api_style, "Auto")
 		self.assertTrue(doc.enabled)
 
 	def test_normalize_strips_whitespace(self):
@@ -139,6 +140,24 @@ class TestFlowModelParams(IntegrationTestCase):
 				doc = frappe.get_doc(_model(params=f'{{"{reserved}": "x"}}'))
 				with self.assertRaisesRegex(frappe.ValidationError, "reserved keys"):
 					doc.insert()
+
+
+class TestFlowModelConnection(IntegrationTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_connection_uses_shared_responses_route(self):
+		doc = frappe.get_doc(_model()).insert()
+
+		with (
+			patch("flow.lib.model.resolve_provider_credentials", return_value={}),
+			patch("litellm.completion") as completion,
+		):
+			result = doc.test_connection()
+
+		self.assertTrue(result["ok"])
+		self.assertEqual(completion.call_args.kwargs["model"], "openai/responses/gpt-4o-mini")
+		self.assertEqual(completion.call_args.kwargs["messages"], [{"role": "user", "content": "ping"}])
 
 
 class TestContextWindow(IntegrationTestCase):

--- a/flow/flow/doctype/flow_model/test_flow_model.py
+++ b/flow/flow/doctype/flow_model/test_flow_model.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from flow.flow.doctype.flow_model.flow_model import _detect_context_window
+from flow.flow.doctype.flow_model.flow_model import CONNECTION_TEST_MAX_TOKENS, _detect_context_window
 
 
 def _model(**overrides: Any) -> dict:
@@ -158,6 +158,7 @@ class TestFlowModelConnection(IntegrationTestCase):
 		self.assertTrue(result["ok"])
 		self.assertEqual(completion.call_args.kwargs["model"], "openai/responses/gpt-4o-mini")
 		self.assertEqual(completion.call_args.kwargs["messages"], [{"role": "user", "content": "ping"}])
+		self.assertEqual(completion.call_args.kwargs["max_tokens"], CONNECTION_TEST_MAX_TOKENS)
 
 
 class TestContextWindow(IntegrationTestCase):

--- a/flow/lib/model.py
+++ b/flow/lib/model.py
@@ -11,6 +11,10 @@ from typing import Any
 import frappe
 
 DEFAULT_TIMEOUT = 60
+API_STYLE_AUTO = "Auto"
+API_STYLE_RESPONSES = "Responses"
+API_STYLE_CHAT_COMPLETIONS = "Chat Completions"
+API_STYLES = frozenset({API_STYLE_AUTO, API_STYLE_RESPONSES, API_STYLE_CHAT_COMPLETIONS})
 
 
 @dataclass
@@ -50,9 +54,10 @@ class Model:
 		base_url: str | None = None,
 		params: dict[str, Any] | None = None,
 		timeout: int = DEFAULT_TIMEOUT,
+		api_style: str | None = None,
 	):
 		if name is not None:
-			if model_id or api_key or base_url or params:
+			if model_id or api_key or base_url or params or api_style is not None:
 				raise ValueError("Pass either a Flow Model doc name or explicit kwargs, not both.")
 			doc = frappe.get_doc("Flow Model", name)
 			if not doc.enabled:
@@ -61,9 +66,13 @@ class Model:
 			api_key = doc.get_password("api_key", raise_exception=False)
 			base_url = doc.base_url or None
 			params = json.loads(doc.params) if doc.params else {}
+			api_style = getattr(doc, "api_style", None) or API_STYLE_AUTO
 
 		if not model_id:
 			raise ValueError("model_id is required")
+		api_style = api_style or API_STYLE_AUTO
+		if api_style not in API_STYLES:
+			raise ValueError(f"api_style must be one of {sorted(API_STYLES)}, got {api_style!r}")
 
 		# Fall back to the central Flow Provider store for anything not set on the model itself.
 		provider_creds = resolve_provider_credentials(model_id)
@@ -77,6 +86,7 @@ class Model:
 		self.base_url = base_url
 		self.params = params or {}
 		self.timeout = timeout
+		self.api_style = api_style
 
 	def chat(
 		self,
@@ -93,7 +103,7 @@ class Model:
 			messages = [{"role": "user", "content": messages}]
 
 		kwargs: dict[str, Any] = {
-			"model": self.model_id,
+			"model": route_model_id(self.model_id, self.api_style, self.base_url),
 			"api_key": self._api_key,
 			"messages": messages,
 			"timeout": self.timeout,
@@ -110,6 +120,30 @@ class Model:
 			return _consume_stream(litellm.completion(**kwargs))
 
 		return _normalize(litellm.completion(**kwargs))
+
+
+def route_model_id(model_id: str, api_style: str | None = None, base_url: str | None = None) -> str:
+	"""Return the LiteLLM model ID for the selected OpenAI API style.
+
+	LiteLLM's completion compatibility layer selects the Responses API when the
+	OpenAI provider-relative model starts with ``responses/``. Other providers,
+	and custom endpoints in Auto mode, retain LiteLLM's default routing.
+	"""
+	api_style = api_style or API_STYLE_AUTO
+	if api_style not in API_STYLES:
+		raise ValueError(f"api_style must be one of {sorted(API_STYLES)}, got {api_style!r}")
+	if not model_id.startswith("openai/"):
+		return model_id
+
+	provider_model = model_id.removeprefix("openai/")
+	is_responses_model = provider_model.startswith("responses/")
+	use_responses = api_style == API_STYLE_RESPONSES or (api_style == API_STYLE_AUTO and not base_url)
+
+	if use_responses and not is_responses_model:
+		return f"openai/responses/{provider_model}"
+	if api_style == API_STYLE_CHAT_COMPLETIONS and is_responses_model:
+		return f"openai/{provider_model.removeprefix('responses/')}"
+	return model_id
 
 
 def resolve_provider_credentials(model_id: str) -> dict[str, Any]:

--- a/flow/tests/test_ai_model.py
+++ b/flow/tests/test_ai_model.py
@@ -6,7 +6,15 @@ from unittest.mock import patch
 
 from frappe.tests import UnitTestCase
 
-from flow.lib.model import ChatResponse, Model, ToolCall, ToolCallBegin
+from flow.lib.model import (
+	API_STYLE_CHAT_COMPLETIONS,
+	API_STYLE_RESPONSES,
+	ChatResponse,
+	Model,
+	ToolCall,
+	ToolCallBegin,
+	route_model_id,
+)
 
 
 def _fake_response(content=None, tool_calls=None, finish_reason="stop", usage=None):
@@ -68,6 +76,7 @@ class TestModel(UnitTestCase):
 		self.assertEqual(m.model_id, "anthropic/claude-sonnet-4-6")
 		self.assertEqual(m._api_key, "sk-stored")
 		self.assertEqual(m.params, {"temperature": 0.3})
+		self.assertEqual(m.api_style, "Auto")
 
 	@patch("frappe.get_doc")
 	def test_init_rejects_disabled_doc(self, mock_get_doc):
@@ -124,6 +133,7 @@ class TestModel(UnitTestCase):
 		self.assertEqual(call.name, "get_weather")
 		self.assertEqual(call.arguments, {"city": "Mumbai"})
 		self.assertEqual(resp.finish_reason, "tool_calls")
+		self.assertEqual(mock_completion.call_args.kwargs["model"], "openai/responses/gpt-4.1")
 
 	@patch("litellm.completion")
 	def test_chat_returns_error_for_invalid_tool_arguments(self, mock_completion):
@@ -162,6 +172,7 @@ class TestModel(UnitTestCase):
 		self.assertEqual(response.finish_reason, "stop")
 		self.assertEqual(response.usage["total_tokens"], 7)
 		self.assertEqual(response.tool_calls, [])
+		self.assertEqual(mock_completion.call_args.kwargs["model"], "openai/responses/gpt-4.1")
 
 	@patch("litellm.completion")
 	def test_chat_stream_assembles_tool_calls_across_chunks(self, mock_completion):
@@ -237,3 +248,49 @@ class TestModel(UnitTestCase):
 		self.assertEqual(kwargs["max_tokens"], 100)
 		self.assertEqual(kwargs["tools"], tools)
 		self.assertEqual(kwargs["timeout"], 60)
+
+	def test_route_model_id_auto_routes_only_direct_openai(self):
+		self.assertEqual(route_model_id("openai/gpt-4.1"), "openai/responses/gpt-4.1")
+		self.assertEqual(
+			route_model_id("openai/gpt-4.1", base_url="https://proxy.example.com/v1"),
+			"openai/gpt-4.1",
+		)
+		self.assertEqual(route_model_id("anthropic/claude-sonnet-4-6"), "anthropic/claude-sonnet-4-6")
+
+	def test_route_model_id_honors_explicit_openai_overrides(self):
+		self.assertEqual(
+			route_model_id(
+				"openai/gpt-4.1",
+				API_STYLE_RESPONSES,
+				"https://proxy.example.com/v1",
+			),
+			"openai/responses/gpt-4.1",
+		)
+		self.assertEqual(
+			route_model_id("openai/responses/gpt-4.1", API_STYLE_CHAT_COMPLETIONS),
+			"openai/gpt-4.1",
+		)
+
+	@patch("litellm.completion")
+	def test_chat_preserves_persisted_tool_result_messages_when_routing(self, mock_completion):
+		mock_completion.return_value = _fake_response(content="done")
+		messages = [
+			{
+				"role": "assistant",
+				"content": None,
+				"tool_calls": [
+					{
+						"id": "call_abc",
+						"type": "function",
+						"function": {"name": "get_weather", "arguments": '{"city":"Mumbai"}'},
+					}
+				],
+			},
+			{"role": "tool", "tool_call_id": "call_abc", "content": "sunny"},
+		]
+
+		Model(model_id="openai/gpt-4.1", api_key="sk-test").chat(messages)
+
+		kwargs = mock_completion.call_args.kwargs
+		self.assertEqual(kwargs["model"], "openai/responses/gpt-4.1")
+		self.assertEqual(kwargs["messages"], messages)


### PR DESCRIPTION
## Problem

Flow always sends chat calls through LiteLLM's Chat Completions path. That remains valid for many models, but OpenAI is increasingly Responses-first; those models can reject or lose tool-call behavior when forced through `/chat/completions`.

There is currently no supported way to select the Responses API or deliberately retain Chat Completions for a proxy.

## Change

- add an **API Style** setting to Flow Model: `Auto`, `Responses`, or `Chat Completions`
- route direct official `openai/*` models through LiteLLM's Responses bridge in Auto mode
- leave custom-base/proxy OpenAI connections and non-OpenAI providers on LiteLLM's existing/default route in Auto mode
- allow either route to be selected explicitly
- use the same routing helper for normal calls, streaming calls, persisted tool-result conversations, and **Test Connection**

The implementation continues to call `litellm.completion()`. It selects LiteLLM's built-in Responses bridge through the canonical `openai/responses/<model>` ID, so Flow keeps its current normalized `ModelResponse`, streaming, and tool-call handling instead of maintaining a second parser.

## Compatibility

- existing Flow Model rows default to `Auto`
- non-OpenAI providers are unchanged
- OpenAI-compatible proxies with a custom Base URL are unchanged in Auto mode
- users can explicitly choose Chat Completions when required

## Validation

- focused tests cover Auto routing, explicit overrides, tool calls, streaming, persisted assistant/tool messages, and Test Connection
- changed-file Ruff/format, Python compilation, JSON validation, and diff checks pass
- the Responses bridge was also smoke-tested against a local `/v1/responses` endpoint with a real function-call response

This is the first isolated change in a planned provider-connection cleanup; it has no dependency on the fork's Frappe 16-specific features.
